### PR TITLE
Dockerfile Alpine and removing build warnings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+Readme.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.gitignore
 Dockerfile
 Readme.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM centos:7
+FROM alpine
 WORKDIR /zsign
-RUN yum -y install gcc gcc-c++ openssl-devel zip unzip
-COPY . .
-RUN g++ *.cpp common/*.cpp -lcrypto -O3 -o zsign
-ENTRYPOINT [ "/zsign/zsign" ]
-CMD [ "/zsign/zsign", "-v" ]
+COPY . src/
+
+RUN apk add --no-cache --virtual .build-deps g++ openssl-dev && \
+	apk add --no-cache libgcc libstdc++ zip unzip && \
+	g++ src/*.cpp src/common/*.cpp -lcrypto -O3 -o zsign && \
+	apk del .build-deps && \
+	rm -rf src
+
+ENTRYPOINT ["/zsign/zsign"]
+CMD ["-v"]

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "base64.h"
+#include <inttypes.h>
 #include <openssl/sha.h>
 
 #define PARSEVALIST(szFormatArgs, szArgs)                       \
@@ -352,7 +353,7 @@ string FormatSize(int64_t size, int64_t base)
 	}
 	else
 	{
-		sprintf(ret, "%lld B", size);
+		sprintf(ret, "%" PRId64 " B", size);
 	}
 	return ret;
 }

--- a/common/json.cpp
+++ b/common/json.cpp
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <assert.h>
 #include <stdarg.h>
+#include <inttypes.h>
 #include <math.h>
 #include <sys/stat.h>
 #include "base64.h"
@@ -388,7 +389,7 @@ string JValue::asString() const
 	case E_INT:
 	{
 		char buf[256];
-		sprintf(buf, "%lld", m_Value.vInt64);
+		sprintf(buf, "%" PRId64, m_Value.vInt64);
 		return buf;
 	}
 	break;
@@ -1889,7 +1890,7 @@ void JWriter::PushValue(const string &strval)
 string JWriter::v2s(int64_t val)
 {
 	char buf[32];
-	sprintf(buf, "%lld", val);
+	sprintf(buf, "%" PRId64, val);
 	return buf;
 }
 
@@ -3005,7 +3006,7 @@ void PWriter::FastWriteValue(const JValue &pval, string &strdoc, string &strinde
 		strdoc += strindent;
 		strdoc += "<integer>";
 		char temp[32] = {0};
-		sprintf(temp, "%lld", pval.asInt64());
+		sprintf(temp, "%" PRId64, pval.asInt64());
 		strdoc += temp;
 		strdoc += "</integer>\n";
 	}
@@ -3024,7 +3025,7 @@ void PWriter::FastWriteValue(const JValue &pval, string &strdoc, string &strinde
 			char temp[32] = {0};
 			if (floor(v) == v)
 			{
-				sprintf(temp, "%lld", (int64_t)v);
+				sprintf(temp, "%" PRId64, (int64_t)v);
 			}
 			else
 			{


### PR DESCRIPTION
In Dockerfile Centos 7 image replaced to Alpine.

Errors fixed:
```
src/common/common.cpp: In function 'std::string FormatSize(int64_t, int64_t)':
src/common/common.cpp:355:20: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t' {aka 'long int'} [-Wformat=]
  355 |   sprintf(ret, "%lld B", size);
      |                 ~~~^     ~~~~
      |                    |     |
      |                    |     int64_t {aka long int}
      |                    long long int
      |                 %ld
src/common/json.cpp: In member function 'std::string JValue::asString() const':
src/common/json.cpp:391:20: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t' {aka 'long int'} [-Wformat=]
  391 |   sprintf(buf, "%lld", m_Value.vInt64);
      |                 ~~~^   ~~~~~~~~~~~~~~
      |                    |           |
      |                    |           int64_t {aka long int}
      |                    long long int
      |                 %ld
src/common/json.cpp: In static member function 'static std::string JWriter::v2s(int64_t)':
src/common/json.cpp:1892:19: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t' {aka 'long int'} [-Wformat=]
 1892 |  sprintf(buf, "%lld", val);
      |                ~~~^   ~~~
      |                   |   |
      |                   |   int64_t {aka long int}
      |                   long long int
      |                %ld
src/common/json.cpp: In static member function 'static void PWriter::FastWriteValue(const JValue&, std::string&, std::string&)':
src/common/json.cpp:3008:21: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t' {aka 'long int'} [-Wformat=]
 3008 |   sprintf(temp, "%lld", pval.asInt64());
      |                  ~~~^   ~~~~~~~~~~~~~~
      |                     |               |
      |                     long long int   int64_t {aka long int}
      |                  %ld
src/common/json.cpp:3027:23: warning: format '%lld' expects argument of type 'long long int', but argument 3 has type 'int64_t' {aka 'long int'} [-Wformat=]
 3027 |     sprintf(temp, "%lld", (int64_t)v);
      |                    ~~~^   ~~~~~~~~~~
      |                       |   |
      |                       |   int64_t {aka long int}
      |                       long long int
      |                    %ld

```