### PR TITLE
add xmake.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ zsign
 *.dSYM
 *.ipa
 .zsign*
+.xmake
+build

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,0 +1,81 @@
+-- add rules: debug/release
+add_rules("mode.debug", "mode.release")
+
+-- add requires
+add_requires("openssl")
+
+-- define target
+target("zsign")
+    set_kind("binary")
+    add_files("*.cpp", "common/*.cpp")
+    add_packages("openssl")
+
+--
+-- FAQ
+--
+-- You can enter the project directory firstly before building project.
+--
+--   $ cd projectdir
+--
+-- 1. How to build project?
+--
+--   $ xmake
+--
+-- 2. How to configure project?
+--
+--   $ xmake f -p [macosx|linux|iphoneos ..] -a [x86_64|i386|arm64 ..] -m [debug|release]
+--
+-- 3. Where is the build output directory?
+--
+--   The default output directory is `./build` and you can configure the output directory.
+--
+--   $ xmake f -o outputdir
+--   $ xmake
+--
+-- 4. How to run and debug target after building project?
+--
+--   $ xmake run [targetname]
+--   $ xmake run -d [targetname]
+--
+-- 5. How to install target to the system directory or other output directory?
+--
+--   $ xmake install
+--   $ xmake install -o installdir
+--
+-- 6. Add some frequently-used compilation flags in xmake.lua
+--
+-- @code
+--    -- add debug and release modes
+--    add_rules("mode.debug", "mode.release")
+--
+--    -- add macro defination
+--    add_defines("NDEBUG", "_GNU_SOURCE=1")
+--
+--    -- set warning all as error
+--    set_warnings("all", "error")
+--
+--    -- set language: c99, c++11
+--    set_languages("c99", "c++11")
+--
+--    -- set optimization: none, faster, fastest, smallest
+--    set_optimize("fastest")
+--
+--    -- add include search directories
+--    add_includedirs("/usr/include", "/usr/local/include")
+--
+--    -- add link libraries and search directories
+--    add_links("tbox")
+--    add_linkdirs("/usr/local/lib", "/usr/lib")
+--
+--    -- add system link libraries
+--    add_syslinks("z", "pthread")
+--
+--    -- add compilation and link flags
+--    add_cxflags("-stdnolib", "-fno-strict-aliasing")
+--    add_ldflags("-L/usr/local/lib", "-lpthread", {force = true})
+--
+-- @endcode
+--
+-- 7. If you want to known more usage about xmake, please see https://xmake.io
+--
+


### PR DESCRIPTION
Add xmake.lua files to compile zsign across platforms, and it automatically solves package dependency issues.

We need only run `$ xmake` to build zsign. It will find openssl from system or download and install  openssl automatically.

Install xmake:  see https://xmake.io

Build:

```console
xmake
```

Run:

```console
xmake run zsign [-options] [-k privkey.pem] [-m dev.prov] [-o output.ipa] file|folder
```

Install to system(/usr/bin):

```console
xmake install
```

Get zsign binary:

```console
xmake install -o outputdir
```

outputdir/bin/zsign