### PR TITLE
Remove adding .ipa suffix

### DIFF
--- a/zsign.cpp
+++ b/zsign.cpp
@@ -228,11 +228,6 @@ int main(int argc, char *argv[])
 			return -1;
 		}
 
-		if (!IsPathSuffix(strOutputFile, ".ipa"))
-		{
-			strOutputFile += ".ipa";
-		}
-
 		ZLog::PrintV(">>> Archiving: \t%s ... \n", strOutputFile.c_str());
 		string strBaseFolder = bundle.m_strAppFolder.substr(0, pos);
 		char szOldFolder[PATH_MAX] = {0};


### PR DESCRIPTION
When i provide output path i want to store output exactly in this path. 

When tool adding .ipa suffix i'm getting unexpected result