### PR TITLE
Windows port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,52 @@ and then (attention to replace your openssl version)
 g++ *.cpp common/*.cpp -lcrypto -I/usr/local/Cellar/openssl/1.0.2s/include -L/usr/local/Cellar/openssl/1.0.2s/lib -O3 -o zsign
 ```
 
+#### Windows/MingW:
+Note:  These instructions describe how to cross-compile for Windows from
+Linux.  I haven't tested these steps compiling for Windows from Windows,
+but it should mostly work.
+
+These instructions assume that mman-win32, zsign, and openssl are all
+sibling directories
+
+1.  Install MingW
+```bash
+apt-get install mingw-w64
+
+```
+2. Build mman-win32
+
+```bash
+git clone git@github.com:witwall/mman-win32
+cd mman-win32
+./configure ----cross-prefix=x86_64-w64-mingw32-
+make
+```
+
+3.  Build openssl
+```
+git clone github.com:openssl/openssl
+cd openssl
+git checkout OpenSSL_1_0_2s
+./Configure --cross-compile-prefix=x86_64-w64-mingw32 mingw64
+make
+
+```
+
+4. Build zsign
+```bash
+x86_64-w64-mingw32-g++  \
+*.cpp common/*.cpp -o zsign.exe 
+-lcrypto -I../mman-win32 
+-std=c++11  -I../openssl/include/  
+-DWINDOWS -L../openssl 
+-L../mman-win32 
+-lmman -lgdi32  
+-m64 -static -static-libgcc
+```
+
 #### CentOS7:
+
 
 ```bash
 yum install openssl-devel

--- a/bundle.cpp
+++ b/bundle.cpp
@@ -1,6 +1,9 @@
 #include "bundle.h"
 #include "macho.h"
+#include "sys/stat.h"
+#include "sys/types.h"
 #include "common/base64.h"
+#include "common/common.h"
 
 ZAppBundle::ZAppBundle()
 {
@@ -8,6 +11,8 @@ ZAppBundle::ZAppBundle()
 	m_bForceSign = false;
 	m_bWeakInject = false;
 }
+
+
 
 bool ZAppBundle::FindAppFolder(const string &strFolder, string &strAppFolder)
 {
@@ -25,7 +30,7 @@ bool ZAppBundle::FindAppFolder(const string &strFolder, string &strAppFolder)
 		{
 			if (0 != strcmp(ptr->d_name, ".") && 0 != strcmp(ptr->d_name, ".."))
 			{
-				if (DT_DIR == ptr->d_type)
+				if (IsFolder(ptr->d_name))
 				{
 					string strSubFolder = strFolder;
 					strSubFolder += "/";
@@ -91,7 +96,7 @@ bool ZAppBundle::GetObjectsToSign(const string &strFolder, JValue &jvInfo)
 			if (0 != strcmp(ptr->d_name, ".") && 0 != strcmp(ptr->d_name, ".."))
 			{
 				string strNode = strFolder + "/" + ptr->d_name;
-				if (DT_DIR == ptr->d_type)
+				if (IsFolder(ptr->d_name))
 				{
 					if (IsPathSuffix(strNode, ".app") || IsPathSuffix(strNode, ".appex") || IsPathSuffix(strNode, ".framework") || IsPathSuffix(strNode, ".xctest"))
 					{
@@ -112,7 +117,7 @@ bool ZAppBundle::GetObjectsToSign(const string &strFolder, JValue &jvInfo)
 						GetObjectsToSign(strNode, jvInfo);
 					}
 				}
-				else if (DT_REG == ptr->d_type)
+				else if (IsRegularFile(ptr->d_name))
 				{
 					if (IsPathSuffix(strNode, ".dylib"))
 					{
@@ -140,11 +145,11 @@ void ZAppBundle::GetFolderFiles(const string &strFolder, const string &strBaseFo
 				string strNode = strFolder;
 				strNode += "/";
 				strNode += ptr->d_name;
-				if (DT_DIR == ptr->d_type)
+				if (IsFolder(ptr->d_name))
 				{
 					GetFolderFiles(strNode, strBaseFolder, setFiles);
 				}
-				else if (DT_REG == ptr->d_type)
+				else if (IsRegularFile(ptr->d_name))
 				{
 					setFiles.insert(strNode.substr(strBaseFolder.size() + 1));
 				}
@@ -435,7 +440,7 @@ void ZAppBundle::GetPlugIns(const string &strFolder, vector<string> &arrPlugIns)
 		{
 			if (0 != strcmp(ptr->d_name, ".") && 0 != strcmp(ptr->d_name, ".."))
 			{
-				if (DT_DIR == ptr->d_type)
+				if (IsFolder(ptr->d_name))
 				{
 					string strSubFolder = strFolder;
 					strSubFolder += "/";

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1,7 +1,6 @@
 #include "common.h"
 #include "base64.h"
 #include <cinttypes>
-#include <sys/wait.h>
 #include <sys/stat.h>
 #include <inttypes.h>
 #include <openssl/sha.h>
@@ -430,6 +429,7 @@ bool SystemExec(const char *szFormatCmd, ...)
 	}
 	else
 	{
+	    #if !defined(WINDOWS)
 		if (WIFEXITED(status))
 		{
 			if (0 == WEXITSTATUS(status))
@@ -446,6 +446,7 @@ bool SystemExec(const char *szFormatCmd, ...)
 		{
 			return true;
 		}
+		#endif
 	}
 	return false;
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -26,9 +26,9 @@
 	}
 
 
-bool IsRegularFile(const string &stringFolder) {
+bool IsRegularFile(const char *file) {
     struct stat info;
-    stat(stringFolder.c_str(), &info);
+    stat(file, &info);
     return S_ISREG(info.st_mode) ;
 }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1,5 +1,8 @@
 #include "common.h"
 #include "base64.h"
+#include <cinttypes>
+#include <sys/wait.h>
+#include <sys/stat.h>
 #include <inttypes.h>
 #include <openssl/sha.h>
 
@@ -22,6 +25,13 @@
 			va_end(args);                                       \
 		}                                                       \
 	}
+
+
+bool IsRegularFile(const string &stringFolder) {
+    struct stat info;
+    stat(stringFolder.c_str(), &info);
+    return S_ISREG(info.st_mode) ;
+}
 
 void *MapFile(const char *path, size_t offset, size_t size, size_t *psize, bool ro)
 {
@@ -191,7 +201,11 @@ bool CreateFolder(const char *szFolder)
 {
 	if (!IsFolder(szFolder))
 	{
+	    #if defined(WINDOWS)
+	    return (0 == mkdir(szFolder));
+	    #else
 		return (0 == mkdir(szFolder, 0755));
+		#endif
 	}
 	return false;
 }
@@ -269,6 +283,7 @@ bool IsZipFile(const char *szFile)
 	}
 	return false;
 }
+#define PATH_BUFFER_LENGTH 1024
 
 string GetCanonicalizePath(const char *szPath)
 {
@@ -278,12 +293,24 @@ string GetCanonicalizePath(const char *szPath)
 		if ('/' != szPath[0])
 		{
 			char path[PATH_MAX] = {0};
+
+			#if defined(WINDOWS)
+
+			if (NULL != _fullpath((char *)"./", path, PATH_BUFFER_LENGTH))
+			{
+				strPath = path;
+				strPath += "/";
+				strPath += szPath;
+			}
+			#else
 			if (NULL != realpath("./", path))
 			{
 				strPath = path;
 				strPath += "/";
 				strPath += szPath;
 			}
+			#endif
+
 		}
 		StringReplace(strPath, "/./", "/");
 	}

--- a/common/common.h
+++ b/common/common.h
@@ -29,6 +29,12 @@ using namespace std;
 #define LE(x) _Swap(x)
 #define BE(x) _Swap(x)
 
+
+#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
+
 uint16_t _Swap(uint16_t value);
 uint32_t _Swap(uint32_t value);
 uint64_t _Swap(uint64_t value);
@@ -42,7 +48,7 @@ bool WriteFile(const char *szData, size_t sLen, const char *szFormatPath, ...);
 bool AppendFile(const char *szFile, const string &strData);
 bool AppendFile(const char *szFile, const char *szData, size_t sLen);
 bool AppendFile(const string &strData, const char *szFormatPath, ...);
-
+bool IsRegularFile(const char *szFile);
 bool IsFolder(const char *szFolder);
 bool IsFolderV(const char *szFormatPath, ...);
 bool CreateFolder(const char *szFolder);

--- a/common/json.h
+++ b/common/json.h
@@ -24,9 +24,13 @@ typedef unsigned long long int uint64_t;
 #include <queue>
 #include <vector>
 #include <string>
+#include <string.h>
 #include <limits>
 #include <algorithm>
+#include <cinttypes>
 using namespace std;
+
+
 
 class JValue
 {


### PR DESCRIPTION
Hello and thanks for your awesome work on zsign.  I'm creating some plugins for Maven and Gradle (java), and I needed to be able to sign packages for Mac on Windows, Linux, and Mac.

This should be a reasonable first pass at porting zsign to Windows, the only thing that's not currently working is waiting for spawned processes to exit (common.cpp/SystemExec).  I'm not terribly familiar with the Windows corollaries for `WIFEXITED`/`WEXITSTATUS`, so if you have a suggestion I'm happy to implement it.

Screenshot of zsign running on Windows:


![image](https://user-images.githubusercontent.com/2894866/85221763-d4bd2d00-b373-11ea-8e55-d67607e18556.png)


This should be a step towards resolving #24 