### PR TITLE
add AppleWWDRCAG3

### DIFF
--- a/openssl.cpp
+++ b/openssl.cpp
@@ -46,6 +46,33 @@ const char *appleDevCACert = ""
 							 "tGwPDBUf\n"
 							 "-----END CERTIFICATE-----\n";
 
+const char *appleDevCACert_G3 = ""
+                             "-----BEGIN CERTIFICATE-----\n"
+                             "MIIEIjCCAwqgAwIBAgIIAd68xDltoBAwDQYJKoZIhvcNAQEFBQAwYjELMAkGA1UE\n"
+                             "BhMCVVMxEzARBgNVBAoTCkFwcGxlIEluYy4xJjAkBgNVBAsTHUFwcGxlIENlcnRp\n"
+                             "ZmljYXRpb24gQXV0aG9yaXR5MRYwFAYDVQQDEw1BcHBsZSBSb290IENBMB4XDTEz\n"
+                             "MDIwNzIxNDg0N1oXDTIzMDIwNzIxNDg0N1owgZYxCzAJBgNVBAYTAlVTMRMwEQYD\n"
+                             "VQQKDApBcHBsZSBJbmMuMSwwKgYDVQQLDCNBcHBsZSBXb3JsZHdpZGUgRGV2ZWxv\n"
+                             "cGVyIFJlbGF0aW9uczFEMEIGA1UEAww7QXBwbGUgV29ybGR3aWRlIERldmVsb3Bl\n"
+                             "ciBSZWxhdGlvbnMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwggEiMA0GCSqGSIb3\n"
+                             "DQEBAQUAA4IBDwAwggEKAoIBAQDKOFSmy1aqyCQ5SOmM7uxfuH8mkbw0U3rOfGOA\n"
+                             "YXdkXqUHI7Y5/lAtFVZYcC1+xG7BSoU+L/DehBqhV8mvexj/avoVEkkVCBmsqtsq\n"
+                             "Mu2WY2hSFT2Miuy/axiV4AOsAX2XBWfODoWVN2rtCbauZ81RZJ/GXNG8V25nNYB2\n"
+                             "NqSHgW44j9grFU57Jdhav06DwY3Sk9UacbVgnJ0zTlX5ElgMhrgWDcHld0WNUEi6\n"
+                             "Ky3klIXh6MSdxmilsKP8Z35wugJZS3dCkTm59c3hTO/AO0iMpuUhXf1qarunFjVg\n"
+                             "0uat80YpyejDi+l5wGphZxWy8P3laLxiX27Pmd3vG2P+kmWrAgMBAAGjgaYwgaMw\n"
+                             "HQYDVR0OBBYEFIgnFwmpthhgi+zruvZHWcVSVKO3MA8GA1UdEwEB/wQFMAMBAf8w\n"
+                             "HwYDVR0jBBgwFoAUK9BpR5R2Cf70a40uQKb3R01/CF4wLgYDVR0fBCcwJTAjoCGg\n"
+                             "H4YdaHR0cDovL2NybC5hcHBsZS5jb20vcm9vdC5jcmwwDgYDVR0PAQH/BAQDAgGG\n"
+                             "MBAGCiqGSIb3Y2QGAgEEAgUAMA0GCSqGSIb3DQEBBQUAA4IBAQBPz+9Zviz1smwv\n"
+                             "j+4ThzLoBTWobot9yWkMudkXvHcs1Gfi/ZptOllc34MBvbKuKmFysa/Nw0Uwj6OD\n"
+                             "Dc4dR7Txk4qjdJukw5hyhzs+r0ULklS5MruQGFNrCk4QttkdUGwhgAqJTleMa1s8\n"
+                             "Pab93vcNIx0LSiaHP7qRkkykGRIZbVf1eliHe2iK5IaMSuviSRSqpd1VAKmuu0sw\n"
+                             "ruGgsbwpgOYJd+W+NKIByn/c4grmO7i77LpilfMFY0GCzQ87HUyVpNur+cmV6U/k\n"
+                             "TecmmYHpvPm0KdIBembhLoz2IYrF+Hjhga6/05Cdqa3zr/04GpZnMBxRpVzscYqC\n"
+                             "tGwPDBUf\n"
+                             "-----END CERTIFICATE-----\n";
+
 const char *appleRootCACert = ""
 							  "-----BEGIN CERTIFICATE-----\n"
 							  "MIIEuzCCA6OgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBiMQswCQYDVQQGEwJVUzET\n"
@@ -89,7 +116,10 @@ bool GenerateCMS(X509 *scert, EVP_PKEY *spkey, const string &strCDHashData, cons
 		return CMSError();
 	}
 
-	BIO *bother1 = BIO_new_mem_buf(appleDevCACert, strlen(appleDevCACert));
+    unsigned long issuerNameHash = X509_issuer_name_hash(scert);
+    unsigned long appleDevCACertG3NameHash = 0x9b16b75c;
+
+    BIO *bother1 = BIO_new_mem_buf( issuerNameHash == appleDevCACertG3NameHash ? appleDevCACert_G3 : appleDevCACert, strlen(issuerNameHash == appleDevCACertG3NameHash ? appleDevCACert_G3: appleDevCACert));
 	BIO *bother2 = BIO_new_mem_buf(appleRootCACert, strlen(appleRootCACert));
 	if (!bother1 || !bother2)
 	{


### PR DESCRIPTION
use "openssl x509 -noout -issuer_hash -in cert.pem" could get the issuer name hash
Old appleDevCACert Validity: 2013.2.8-2023-2.8, Name hash: 0x817d2f7a  and appleDevCACert_G3 Validity: 2020.2.20-2030-2.20, Name hash: 0x9b16b75c, so should check the scert issuer name hash