### PR TITLE
Build a static linked zsign in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine
 WORKDIR /zsign
 COPY . src/
 
-RUN apk add --no-cache --virtual .build-deps g++ openssl-dev && \
-	apk add --no-cache libgcc libstdc++ zip unzip && \
-	g++ src/*.cpp src/common/*.cpp -lcrypto -O3 -o zsign && \
+RUN apk add --no-cache --virtual .build-deps g++ openssl-dev openssl-libs-static && \
+	apk add --no-cache zip unzip && \
+	g++ src/*.cpp src/common/*.cpp /usr/lib/libcrypto.a -O3 -o zsign -static -static-libgcc && \
 	apk del .build-deps && \
 	rm -rf src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine
 WORKDIR /zsign
 COPY . src/
 
-RUN apk add --no-cache --virtual .build-deps g++ openssl-dev openssl-libs-static && \
-	apk add --no-cache zip unzip && \
-	g++ src/*.cpp src/common/*.cpp /usr/lib/libcrypto.a -O3 -o zsign -static -static-libgcc && \
+RUN apk add --no-cache --virtual .build-deps g++ clang clang-static openssl-dev openssl-libs-static && \
+    apk add --no-cache zip unzip && \
+    clang++ src/*.cpp src/common/*.cpp /usr/lib/libcrypto.a -O3 -o zsign -static && \
 	apk del .build-deps && \
-	rm -rf src
+    rm -rf src
 
 ENTRYPOINT ["/zsign/zsign"]
 CMD ["-v"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zsign
-Maybe is the most quickly codesign alternative for iOS12+ in the world, cross-platform ( Linux & macOS ), more features.  
-If this tool can help you, please don't forget to star me. :) 
+Maybe is the most quickly codesign alternative for iOS12+ in the world, cross-platform ( Linux & macOS ), more features.
+If this tool can help you, please don't forget to star me. :)
 
 ### Compile
 
@@ -51,12 +51,12 @@ make
 4. Build zsign
 ```bash
 x86_64-w64-mingw32-g++  \
-*.cpp common/*.cpp -o zsign.exe 
--lcrypto -I../mman-win32 
--std=c++11  -I../openssl/include/  
--DWINDOWS -L../openssl 
--L../mman-win32 
--lmman -lgdi32  
+*.cpp common/*.cpp -o zsign.exe
+-lcrypto -I../mman-win32
+-std=c++11  -I../openssl/include/
+-DWINDOWS -L../openssl
+-L../mman-win32
+-lmman -lgdi32
 -m64 -static -static-libgcc
 ```
 
@@ -121,7 +121,7 @@ options:
 
 5. Inject dylib into ipa and re-sign.
 ```bash
-./zsign -k dev.p12 -p 123 -m dev.prov -o output.ipa -l demo.dylib demo.ipa 
+./zsign -k dev.p12 -p 123 -m dev.prov -o output.ipa -l demo.dylib demo.ipa
 ```
 
 6. Change bundle id and bundle name
@@ -187,10 +187,17 @@ docker run -v "$PWD:$PWD" -w "$PWD" zsign -k privkey.pem -m dev.prov -o output.i
 docker run -v "/source/input:/target/input" -w "/target/input" zsign -k privkey.pem -m dev.prov -o output.ipa -z 9 demo.ipa
 ```
 
+3. Extract the zsign executable
+
+*You can extract the static linked zsign executable from the container image and deploy it to other server:*
+```
+docker run -v $PWD:/out --rm --entrypoint /bin/cp zsign zsign /out
+```
+
 ### Copyright
 zsign is completely free. Please mark the source of zsign in your commercial product if possible.
 
 ### How to sign quickly?
-You can unzip the ipa file at first, and then using zsign to sign folder with assets.  
-At the first time of sign, zsign will perform the complete signing and cache the signed info into *.zsign_cache* dir at the current path.  
+You can unzip the ipa file at first, and then using zsign to sign folder with assets.
+At the first time of sign, zsign will perform the complete signing and cache the signed info into *.zsign_cache* dir at the current path.
 When you re-sign the folder with other assets next time, zsign will use the cache to accelerate the operation. Extremely fast! You can have a try！：）


### PR DESCRIPTION
A static linked executable makes it easier to deploy to various server environment.

GCC in alpine defaults to `x86_64-alpine-linux-musl` target, which requires dynamic links to musl:

```
# echo 'int main() {}' > test.c
# gcc test.c -static -o with-gcc

# file with-gcc
with-gcc: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped

# ldd with-gcc
	/lib/ld-musl-x86_64.so.1 (0x7f42db475000)
```

When you copy the executable to the host environment:

```
$ file with-gcc
with-gcc: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, with debug_info, not stripped
$ ldd with-gcc
ldd a.out
	statically linked
```

Notice that the output of file and ldd changed.

And with clang, you get consistent result:

In alpine:

```
# clang test.c -static -o with-clang
# file with-clang
with-clang: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped
# ldd with-clang
/lib/ld-musl-x86_64.so.1: with-clang: Not a valid dynamic program
```

In host environment:

```
$ file with-clang
with-clang: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, with debug_info, not stripped
$ ldd with-clang
	not a dynamic executable
```

