### PR TITLE
原来的PReader::decodeString在用于获取字符串类型的value时，忽略任何字符都不对。独立出一个函数decodeStringValue

### DIFF
--- a/common/json.cpp
+++ b/common/json.cpp
@@ -2117,7 +2117,8 @@ bool PReader::readValue(JValue &pval, Token &token)
 	case Token::E_String:
 	{
 		string strval;
-		decodeString(token, strval);
+		//decodeString(token, strval);
+		decodeStringValue(token, strval);
 		XMLUnescape(strval);
 		pval = strval.c_str();
 	}
@@ -2468,6 +2469,21 @@ bool PReader::decodeString(Token &token, string &strdec)
 		{
 			strdec += c;
 		}
+	}
+	return true;
+}
+bool PReader::decodeStringValue(Token &token, string &strdec)
+{
+	const char *pcur = token.pbeg;
+	const char *pend = token.pend;
+	strdec.reserve(size_t(token.pend - token.pbeg) + 6);
+	while (pcur != pend)
+	{
+		char c = *pcur++;
+		//if ('\n' != c && '\r' != c && '\t' != c)
+		//{
+			strdec += c;
+		//}
 	}
 	return true;
 }

--- a/common/json.h
+++ b/common/json.h
@@ -366,6 +366,7 @@ private:
 
 	bool decodeNumber(Token &token, JValue &jval);
 	bool decodeString(Token &token, string &decoded);
+	bool decodeStringValue(Token &token, string &strdec);//用于获取string类型的value
 	bool decodeDouble(Token &token, JValue &jval);
 
 	void skipSpaces();


### PR DESCRIPTION
我用zsign重签后，app功能不正常了，原来是app从Info.plist获取字符串并判断时出错，对比发现，一个字符串的换行消失了。
单步发现是PReader::decodeString忽略的换行。

我没有直接修改PReader::decodeString，因为它用于多处（例如获取key，获取value，等。），在别处它的逻辑是正确的。
添加了一个decodeStringValue，仅用于获取string类型的value。