### PR TITLE
Can't Find App Folder! /tmp/zsign_folder_1598622362395643

### DIFF
--- a/bundle.cpp
+++ b/bundle.cpp
@@ -30,8 +30,22 @@ bool ZAppBundle::FindAppFolder(const string &strFolder, string &strAppFolder)
 		{
 			if (0 != strcmp(ptr->d_name, ".") && 0 != strcmp(ptr->d_name, "..") && 0 != strcmp(ptr->d_name, "__MACOSX"))
 			{
-				if (DT_DIR == ptr->d_type)
-				{
+			    bool isdir = false;
+			    if (DT_DIR == ptr->d_type) {
+			        isdir = true;
+			    }
+			    else if (DT_UNKNOWN == ptr->d_type)
+        	    {
+        	        // Entry type can be unknown depending on the underlying file system
+                    ZLog::DebugV(">>> Unknown directory entry type for %s, falling back to POSIX-compatible check\n", strFolder.c_str());
+                    struct stat statbuf;
+                    stat(strFolder.c_str(), &statbuf);
+                    if (S_ISDIR(statbuf.st_mode))
+                    {
+                        isdir = true;
+                    }
+        	    }
+				if (isdir)				{
 					string strSubFolder = strFolder;
 					strSubFolder += "/";
 					strSubFolder += ptr->d_name;

--- a/bundle.cpp
+++ b/bundle.cpp
@@ -30,22 +30,24 @@ bool ZAppBundle::FindAppFolder(const string &strFolder, string &strAppFolder)
 		{
 			if (0 != strcmp(ptr->d_name, ".") && 0 != strcmp(ptr->d_name, "..") && 0 != strcmp(ptr->d_name, "__MACOSX"))
 			{
-			    bool isdir = false;
-			    if (DT_DIR == ptr->d_type) {
-			        isdir = true;
-			    }
-			    else if (DT_UNKNOWN == ptr->d_type)
-        	    {
-        	        // Entry type can be unknown depending on the underlying file system
-                    ZLog::DebugV(">>> Unknown directory entry type for %s, falling back to POSIX-compatible check\n", strFolder.c_str());
-                    struct stat statbuf;
-                    stat(strFolder.c_str(), &statbuf);
-                    if (S_ISDIR(statbuf.st_mode))
-                    {
-                        isdir = true;
-                    }
-        	    }
-				if (isdir)				{
+				bool isdir = false;
+				if (DT_DIR == ptr->d_type) 
+				{
+				        isdir = true;
+				}
+				else if (DT_UNKNOWN == ptr->d_type)
+				{
+	        			// Entry type can be unknown depending on the underlying file system
+					ZLog::DebugV(">>> Unknown directory entry type for %s, falling back to POSIX-compatible check\n", strFolder.c_str());
+					struct stat statbuf;
+					stat(strFolder.c_str(), &statbuf);
+					if (S_ISDIR(statbuf.st_mode))
+	            			{
+			        		isdir = true;
+					}
+				}
+				if (isdir)
+				{
 					string strSubFolder = strFolder;
 					strSubFolder += "/";
 					strSubFolder += ptr->d_name;


### PR DESCRIPTION
Fixes this error on some Linux file systems with a fallback to stat() when comparing dirent types.