### PR TITLE
ignore invalid .framework to sign

### DIFF
--- a/bundle.cpp
+++ b/bundle.cpp
@@ -74,7 +74,10 @@ bool ZAppBundle::GetSignFolderInfo(const string &strFolder, JValue &jvNode, bool
 	string strBundleVersion = jvInfo["CFBundleVersion"];
 	if (strBundleId.empty() || strBundleVersion.empty() || strBundleExe.empty())
 	{
-		return false;
+		if (!IsPathSuffix(strFolder, ".framework")) {
+			return false;
+		}
+		strBundleVersion = "1.0.0";
 	}
 
 	string strInfoPlistSHA1Base64;


### PR DESCRIPTION
zsign now simulates codesign and ignores the info.plist key-value pair of .framework to prevent some special frameworks from being checked and causing app crashes after signing