### PR TITLE
Fixes invalid code signature on iOS 15.1

### DIFF
--- a/signing.cpp
+++ b/signing.cpp
@@ -724,8 +724,8 @@ bool SlotBuildCMSSignature(ZSignAsset *pSignAsset,
 	string strAltnateCodeDirectorySlot256;
 	SHASum(E_SHASUM_TYPE_1, strCodeDirectorySlot, strCodeDirectorySlotSHA1);
 	SHASum(E_SHASUM_TYPE_256, strAltnateCodeDirectorySlot, strAltnateCodeDirectorySlot256);
-	jvHashes["cdhashes"][0].assignData(strCodeDirectorySlotSHA1.data(), strCodeDirectorySlotSHA1.size());
-	jvHashes["cdhashes"][1].assignData(strAltnateCodeDirectorySlot256.data(), strCodeDirectorySlotSHA1.size());
+	jvHashes["cdhashes"][0].assignData(strAltnateCodeDirectorySlot256.data(), strCodeDirectorySlotSHA1.size());
+	jvHashes["cdhashes"][1].assignData(strCodeDirectorySlotSHA1.data(), strCodeDirectorySlotSHA1.size());
 	jvHashes.writePList(strCDHashesPlist);
 
 	string strCMSData;


### PR DESCRIPTION
Referenced from:
 * From 4844a00d2512e72ecbcd5170339945726ea6fc3b Mon Sep 17 00:00:00 2001
 * From: Riley Testut <riley@rileytestut.com>
 * Date: Wed, 29 Sep 2021 13:32:55 -0600
 * Subject: Fixes invalid code signature on iOS 15.1
 *
 * Switches order of cdhashes so that cdhash 2 (SHA256) is first, which is required by iOS 15.1