### PR TITLE
Add CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(zsign)
+set(CMAKE_CXX_STANDARD 11)
+
+# Dependencies
+
+find_package(OpenSSL REQUIRED)
+message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+include_directories(${OPENSSL_INCLUDE_DIR})
+list(APPEND LIB_LIST ${OPENSSL_LIBRARIES})
+
+find_package(ZLIB REQUIRED)
+message("zlib include dir: ${ZLIB_INCLUDE_DIR}")
+message("zlib libraries: ${ZLIB_LIBRARIES}")
+include_directories(${ZLIB_INCLUDE_DIR})
+list(APPEND LIB_LIST ${ZLIB_LIBRARIES})
+
+
+# Main sources
+
+include_directories(common)
+
+set(COMMON common/base64.cpp common/json.cpp common/common.cpp)
+set(SRC ${COMMON} archo.cpp bundle.cpp macho.cpp openssl.cpp signing.cpp zsign.cpp)
+
+add_executable(zsign ${SRC})
+target_link_libraries(zsign ${LIB_LIST})
+

--- a/README.md
+++ b/README.md
@@ -3,19 +3,23 @@ Maybe is the most quickly codesign alternative for iOS12+ in the world, cross-pl
 If this tool can help you, please don't forget to <font color=#FF0000 size=5>🌟**star**🌟</font> me. :)
 ### Compile
 
-You must install openssl library at first.
+You must install openssl and zlib libraries at first.
 
 #### macOS:
 
 ```bash
 brew install openssl
 ```
-and then (attention to replace your openssl version)
+and then
+
 ```bash
-g++ *.cpp common/*.cpp -lcrypto -I/usr/local/Cellar/openssl@1.1/1.1.1k/include -L/usr/local/Cellar/openssl@1.1/1.1.1k/lib -O3 -o zsign
+mkdir build; cd build
+cmake ..
+make
 ```
 
 #### Windows/MingW:
+
 Note:  These instructions describe how to cross-compile for Windows from
 Linux.  I haven't tested these steps compiling for Windows from Windows,
 but it should mostly work.
@@ -66,11 +70,13 @@ another ref for chinese: https://blog.csdn.net/a513436535/article/details/108539
 
 ```bash
 sudo apt-get install zip unzip git build-essential checkinstall zlib1g-dev libssl-dev -y
-```bash
+```
 
 and then
 ```bash
-g++ *.cpp common/*.cpp -std=gnu++11 -lcrypto -O3 -o zsign
+mkdir build; cd build
+cmake ..
+make
 ```
 
 #### CentOS7:
@@ -81,7 +87,9 @@ yum install openssl-devel
 ```
 and then
 ```bash
-g++ *.cpp common/*.cpp -std=gnu++11 -lcrypto -O3 -o zsign
+mkdir build; cd build
+cmake ..
+make
 ```
 
 ### Usage


### PR DESCRIPTION
To avoid typing long `g++` invocations, also it will make Windows build easier.