### PR TITLE
Fix cmake cannot find OpenSSL on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,24 @@ project(zsign)
 set(CMAKE_CXX_STANDARD 11)
 
 # Dependencies
+# On macOS, search Homebrew for keg-only versions of OpenSSL because system provided /usr/lib/libssl.dylib cannot be linked
+if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
+    execute_process(
+        COMMAND brew --prefix OpenSSL 
+        RESULT_VARIABLE BREW_OPENSSL
+        OUTPUT_VARIABLE BREW_OPENSSL_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (BREW_OPENSSL EQUAL 0 AND EXISTS "${BREW_OPENSSL_PREFIX}")
+        message(STATUS "Found OpenSSL keg installed by Homebrew at ${BREW_OPENSSL_PREFIX}")
+        set(OPENSSL_ROOT_DIR "${BREW_OPENSSL_PREFIX}/")
+        set(OPENSSL_INCLUDE_DIR "${BREW_OPENSSL_PREFIX}/include")
+        set(OPENSSL_LIBRARIES "${BREW_OPENSSL_PREFIX}/lib/libssl.dylib;${BREW_OPENSSL_PREFIX}/lib/libcrypto.dylib")
+    endif()
+else()
+    find_package(OpenSSL REQUIRED)
+endif()
 
-find_package(OpenSSL REQUIRED)
 message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
 message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
 include_directories(${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
Currently the `find_package(OpenSSL REQUIRED)` could result in:
```
Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_INCLUDE_DIR
```
or 
```
OpenSSL libraries: /usr/lib/libssl.dylib
```
which is not linkable:
```
ld: cannot link directly with dylib/framework, your binary is not an allowed client of /usr/lib/libssl.dylib for architecture x86_64
```


This PR forces cmake to use homebrew installed OpenSSL

Would be great if you can add the label hacktoberfest-accepted if this PR is accepted
