### PR TITLE
Update xmake.lua

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -9,6 +9,7 @@ target("zsign")
     set_kind("binary")
     add_files("*.cpp", "common/*.cpp")
     add_packages("openssl")
+    set_languages("c99", "c++11")
 
 --
 -- FAQ


### PR DESCRIPTION
Fix compile error in Redhat Enterprise Linux Server release 7.2 (Paladin):

> /usr/include/c++/4.6/bits/c++0x_warning.h:32:2: error: #error This
file requires compiler and library support for the upcoming ISO C++
standard, C++0x. This support is currently experimental, and must be
enabled with the -std=c++0x or -std=gnu++0x compiler options.