### PR TITLE
 fix: use function _fullpath correctly in GetCanonicalizePath on Windows

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -295,11 +295,9 @@ string GetCanonicalizePath(const char *szPath)
 
 #if defined(WINDOWS)
 
-			if (NULL != _fullpath((char *)"./", path, PATH_BUFFER_LENGTH))
+			if (NULL != _fullpath(path, szPath, PATH_BUFFER_LENGTH))
 			{
 				strPath = path;
-				strPath += "/";
-				strPath += szPath;
 			}
 #else
 			if (NULL != realpath("./", path))


### PR DESCRIPTION
Fix for #251
Function _fullpath needs to be used correctly to return a proper canonical path on Windows OS

Signed-off-by: Marek Forys <forys@o2.pl>