### PR TITLE
Update Unzip to 7zip

### DIFF
--- a/zsign.cpp
+++ b/zsign.cpp
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
 		StringFormat(strFolder, "/tmp/zsign_folder_%llu", timer.Reset());
 		ZLog::PrintV(">>> Unzip:\t%s (%s) -> %s ... \n", strPath.c_str(), GetFileSizeString(strPath.c_str()).c_str(), strFolder.c_str());
 		RemoveFolder(strFolder.c_str());
-		if (!SystemExec("unzip -qq -d '%s' '%s'", strFolder.c_str(), strPath.c_str()))
+		if (!SystemExec("7z x '%s' -oc:'%s'", strPath.c_str(), strFolder.c_str()))
 		{
 			RemoveFolder(strFolder.c_str());
 			ZLog::ErrorV(">>> Unzip Failed!\n");


### PR DESCRIPTION
There's some issue of unzip when uncompressing IPA contains files named in Chinese. I replace the unzip with 7zip to fix the issue ~