### PR TITLE
Erase existing contents of _CodeSignature to prevent integrity errors

### DIFF
--- a/bundle.cpp
+++ b/bundle.cpp
@@ -376,6 +376,7 @@ bool ZAppBundle::SignNode(JValue &jvNode)
 		return false;
 	}
 
+	RemoveFolderV("%s/_CodeSignature", strBaseFolder.c_str());
 	CreateFolderV("%s/_CodeSignature", strBaseFolder.c_str());
 	string strCodeResFile = strBaseFolder + "/_CodeSignature/CodeResources";
 


### PR DESCRIPTION
This was causing problems with the IPA that I was using, it had a ResourceRules file that led to the zSign code signature being invalid.