### PR TITLE
Fix for >>> Can't Load P12 or PrivateKey File! Please Input The Correct File And Password! on Ubuntu

### DIFF
--- a/openssl.cpp
+++ b/openssl.cpp
@@ -5,6 +5,7 @@
 #include <openssl/pem.h>
 #include <openssl/cms.h>
 #include <openssl/err.h>
+#include <openssl/provider.h>
 #include <openssl/pkcs12.h>
 #include <openssl/conf.h>
 
@@ -694,6 +695,7 @@ bool ZSignAsset::Init(const string &strSignerCertFile, const string &strSignerPK
 			if (NULL == evpPKey)
 			{
 				BIO_reset(bioPKey);
+				OSSL_PROVIDER_load(NULL, "legacy");
 				PKCS12 *p12 = d2i_PKCS12_bio(bioPKey, NULL);
 				if (NULL != p12)
 				{


### PR DESCRIPTION
Fixes this error on Ubuntu:

40F73114107F0000:error:1700006B:CMS routines:cms_get_enveloped_type:content type not enveloped data:../crypto/cms/cms_env.c:41:
40F73114107F0000:error:1E08010C:DECODER routines:OSSL_DECODER_from_bio:unsupported:../crypto/encode_decode/decoder_lib.c:101:No supported data to decode. Input type: PEM
40F73114107F0000:error:1E08010C:DECODER routines:OSSL_DECODER_from_bio:unsupported:../crypto/encode_decode/decoder_lib.c:101:No supported data to decode.  Input type: DER, Input structure: type-specific
40F73114107F0000:error:1E08010C:DECODER routines:OSSL_DECODER_from_bio:unsupported:../crypto/encode_decode/decoder_lib.c:101:No supported data to decode.  Input type: DER, Input structure: PrivateKeyInfo
40F73114107F0000:error:1E08010C:DECODER routines:OSSL_DECODER_from_bio:unsupported:../crypto/encode_decode/decoder_lib.c:101:No supported data to decode. Input type: DER
40F73114107F0000:error:068000A8:asn1 encoding routines:asn1_check_tlen:wrong tag:../crypto/asn1/tasn_dec.c:1188:
40F73114107F0000:error:0688010A:asn1 encoding routines:asn1_d2i_ex_primitive:nested asn1 error:../crypto/asn1/tasn_dec.c:752:
40F73114107F0000:error:0688010A:asn1 encoding routines:asn1_template_noexp_d2i:nested asn1 error:../crypto/asn1/tasn_dec.c:685:Field=pkey, Type=PKCS8_PRIV_KEY_INFO
40F73114107F0000:error:068000A7:asn1 encoding routines:d2i_AutoPrivateKey_legacy:unsupported public key type:../crypto/asn1/d2i_pr.c:195:
40F73114107F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
>>> Can't Load P12 or PrivateKey File! Please Input The Correct File And Password!
