### PR TITLE
Add install target for zsign binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,4 @@ file(GLOB SRC common/*.cpp ./**.cpp)
 add_executable(zsign ${SRC})
 target_link_libraries(zsign ${LIB_LIST})
 
+install(TARGETS zsign DESTINATION bin)


### PR DESCRIPTION
This is needed to make 'ninja install' work. Could you also tag a release?