### PR TITLE
Implement zipped Framework injection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,26 +165,29 @@ I have already tested on macOS and Linux, but you also need **unzip** and **zip*
 
 ```bash
 Usage: zsign [-options] [-k privkey.pem] [-m dev.prov] [-o output.ipa] file|folder
-
 options:
--k, --pkey           Path to private key or p12 file. (PEM or DER format)
--m, --prov           Path to mobile provisioning profile.
--c, --cert           Path to certificate file. (PEM or DER format)
--d, --debug          Generate debug output files. (.zsign_debug folder)
--f, --force          Force sign without cache when signing folder.
--o, --output         Path to output ipa file.
--p, --password       Password for private key or p12 file.
--b, --bundle_id      New bundle id to change.
--n, --bundle_name    New bundle name to change.
--r, --bundle_version New bundle version to change.
--e, --entitlements   New entitlements to change.
--z, --zip_level      Compressed level when output the ipa file. (0-9)
--l, --dylib          Path to inject dylib file.
--w, --weak           Inject dylib as LC_LOAD_WEAK_DYLIB.
--i, --install        Install ipa file using ideviceinstaller command for test.
--q, --quiet          Quiet operation.
--v, --version        Show version.
--h, --help           Show help.
+-k, --pkey		Path to private key or p12 file. (PEM or DER format)
+-m, --prov		Path to mobile provisioning profile.
+-c, --cert		Path to certificate file. (PEM or DER format)
+-d, --debug		Generate debug output files. (.zsign_debug folder)
+-f, --force		Force sign without cache when signing folder.
+-o, --output		Path to output ipa file.
+-p, --password		Password for private key or p12 file.
+-b, --bundle_id		New bundle id to change.
+-n, --bundle_name	New bundle name to change.
+-r, --bundle_version	New bundle version to change.
+-e, --entitlements	New entitlements to change.
+-z, --zip_level		Compressed level when output the ipa file. (0-9)
+-l, --dylib		Path to inject dylib file.
+			Use -l multiple time to inject multiple dylib files at once.
+-L, --framework		Path to inject framework file.
+			Framework folder must be zipped (using zip) to .ifw file before injecting.
+			Use -L multiple time to inject multiple framework files at once.
+-w, --weak		Inject dylib as LC_LOAD_WEAK_DYLIB.
+-i, --install		Install ipa file using ideviceinstaller command for test.
+-q, --quiet		Quiet operation.
+-v, --version		Shows version.
+-h, --help		Shows help (this message).
 ```
 
 1. Show mach-o and codesignature segment info.

--- a/bundle.h
+++ b/bundle.h
@@ -12,7 +12,8 @@ public:
   bool SignFolder(ZSignAsset *pSignAsset, const string &strFolder,
                   const string &strBundleID, const string &strBundleVersion,
                   const string &strDisplayName,
-                  const vector<string> &arrDyLibFiles, bool bForce,
+                  const vector<string> &arrDyLibFiles,
+                  const vector<string> &arrFrameworkFiles, bool bForce,
                   bool bWeakInject, bool bEnableCache);
 
 private:

--- a/zsign.cpp
+++ b/zsign.cpp
@@ -23,6 +23,7 @@ const struct option options[] = {
     {"output", required_argument, NULL, 'o'},
     {"zip_level", required_argument, NULL, 'z'},
     {"dylib", required_argument, NULL, 'l'},
+    {"framework", required_argument, NULL, 'L'},
     {"weak", no_argument, NULL, 'w'},
     {"install", no_argument, NULL, 'i'},
     {"quiet", no_argument, NULL, 'q'},
@@ -51,6 +52,11 @@ int usage() {
   ZLog::Print("-l, --dylib\t\tPath to inject dylib file.\n");
   ZLog::Print(
       "\t\t\tUse -l multiple time to inject multiple dylib files at once.\n");
+  ZLog::Print("-L, --framework\t\tPath to inject framework file.\n");
+  ZLog::Print("\t\t\tFramework folder must be zipped (using zip) to .ifw file "
+              "before injecting.\n");
+  ZLog::Print("\t\t\tUse -L multiple time to inject multiple framework files "
+              "at once.\n");
   ZLog::Print("-w, --weak\t\tInject dylib as LC_LOAD_WEAK_DYLIB.\n");
   ZLog::Print("-i, --install\t\tInstall ipa file using ideviceinstaller "
               "command for test.\n");
@@ -80,10 +86,11 @@ int main(int argc, char *argv[]) {
   string strEntitlementsFile;
 
   vector<string> arrDyLibFiles;
+  vector<string> arrFrameworkFiles;
 
   int opt = 0;
   int argslot = -1;
-  while (-1 != (opt = getopt_long(argc, argv, "dfvhc:k:m:o:ip:e:b:n:z:ql:w",
+  while (-1 != (opt = getopt_long(argc, argv, "dfvhc:k:m:o:ip:e:b:n:z:ql:L:w",
                                   options, &argslot))) {
     switch (opt) {
     case 'd':
@@ -118,6 +125,9 @@ int main(int argc, char *argv[]) {
       break;
     case 'l':
       arrDyLibFiles.push_back(optarg);
+      break;
+    case 'L':
+      arrFrameworkFiles.push_back(optarg);
       break;
     case 'i':
       bInstall = true;
@@ -211,9 +221,9 @@ int main(int argc, char *argv[]) {
 
   timer.Reset();
   ZAppBundle bundle;
-  bool bRet = bundle.SignFolder(&zSignAsset, strFolder, strBundleId,
-                                strBundleVersion, strDisplayName, arrDyLibFiles,
-                                bForce, bWeakInject, bEnableCache);
+  bool bRet = bundle.SignFolder(
+      &zSignAsset, strFolder, strBundleId, strBundleVersion, strDisplayName,
+      arrDyLibFiles, arrFrameworkFiles, bForce, bWeakInject, bEnableCache);
   timer.PrintResult(bRet, ">>> Signed %s!", bRet ? "OK" : "Failed");
 
   if (bInstall && strOutputFile.empty()) {


### PR DESCRIPTION
Framework folders must be zipped before injecting.

Standard zip extension is `.ifw`.

Zip file must contain Framework folder at root not the Framework's content.
