### PR TITLE
SlotBuildRequirements: fix serialization of empty `CSSLOT_REQUIREMENTS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(zsign)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # Dependencies
 # On macOS, search Homebrew for keg-only versions of OpenSSL because system provided /usr/lib/libssl.dylib cannot be linked

--- a/signing.cpp
+++ b/signing.cpp
@@ -3,6 +3,8 @@
 #include "common/mach-o.h"
 #include "openssl.h"
 
+#include <string_view>
+
 static void _DERLength(string &strBlob, uint64_t uLength)
 {
 	if (uLength < 128)
@@ -163,7 +165,7 @@ bool SlotBuildRequirements(const string &strBundleID, const string &strSubjectCN
 	strOutput.clear();
 	if (strBundleID.empty() || strSubjectCN.empty())
 	{ //ldid
-		strOutput = "\xfa\xde\x0c\x01\x00\x00\x00\x0c\x00\x00\x00\x00";
+		strOutput = "\xfa\xde\x0c\x01\x00\x00\x00\x0c\x00\x00\x00\x00"sv;
 		return true;
 	}
 


### PR DESCRIPTION
`strOutput` was assigned from C zero-terminated string literal (via `operator=(const char *)`), which cuts at first occurrence of `\0`.  This resulted in incorrect serialization of empty `CSSLOT_REQUIREMENTS`.

Use `operator""sv` to construct a `std::string_view` instead.  Because [`operator""sv`](https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv) requires C++17, also update `CMAKE_CXX_STANDARD`.