### PR TITLE
Implement ad-hoc signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(zsign)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # Dependencies
 # On macOS, search Homebrew for keg-only versions of OpenSSL because system provided /usr/lib/libssl.dylib cannot be linked

--- a/archo.cpp
+++ b/archo.cpp
@@ -430,7 +430,9 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 	string strCMSSignatureSlot;
 	string strCodeDirectorySlot;
 	string strAltnateCodeDirectorySlot;
-	SlotBuildCodeDirectory(false,
+	if (!pSignAsset->m_bUseSHA256Only)
+	{
+		SlotBuildCodeDirectory(false,
 						   m_pBase,
 						   m_uCodeLength,
 						   pCodeSlots1Data,
@@ -447,6 +449,7 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 						   IsExecute(),
 						   pSignAsset->m_bAdhoc,
 						   strCodeDirectorySlot);
+	}
 	SlotBuildCodeDirectory(true,
 						   m_pBase,
 						   m_uCodeLength,
@@ -464,6 +467,12 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 						   IsExecute(),
 						   pSignAsset->m_bAdhoc,
 						   strAltnateCodeDirectorySlot);
+	if (pSignAsset->m_bUseSHA256Only)
+	{
+		// SHA256-based code directory is usually the alternate; however, make it the primary (and only)
+		// code directory if `m_bUseSHA256Only == true`.
+		strAltnateCodeDirectorySlot.swap(strCodeDirectorySlot);
+	}
 	SlotBuildCMSSignature(pSignAsset,
 						  strCodeDirectorySlot,
 						  strAltnateCodeDirectorySlot,

--- a/archo.cpp
+++ b/archo.cpp
@@ -420,11 +420,11 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 		GetCodeSignatureExistsCodeSlotsData(m_pSignBase, pCodeSlots1Data, uCodeSlots1DataLength, pCodeSlots256Data, uCodeSlots256DataLength);
 	}
 
-	uint64_t execSegFlags = 0;
+	uint64_t execSegFlags = pSignAsset->m_bSingleBinary ? CS_EXECSEG_MAIN_BINARY : 0U;
 	if (NULL != strstr(strEntitlementsSlot.data() + 8, "<key>get-task-allow</key>"))
 	{
 		// TODO: Check if get-task-allow is actually set to true
-		execSegFlags = CS_EXECSEG_MAIN_BINARY | CS_EXECSEG_ALLOW_UNSIGNED;
+		execSegFlags |= CS_EXECSEG_MAIN_BINARY | CS_EXECSEG_ALLOW_UNSIGNED;
 	}
 
 	string strCMSSignatureSlot;
@@ -445,6 +445,7 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 						   strEntitlementsSlotSHA1,
 						   strDerEntitlementsSlotSHA1,
 						   IsExecute(),
+						   pSignAsset->m_bAdhoc,
 						   strCodeDirectorySlot);
 	SlotBuildCodeDirectory(true,
 						   m_pBase,
@@ -461,6 +462,7 @@ bool ZArchO::BuildCodeSignature(ZSignAsset *pSignAsset, bool bForce, const strin
 						   strEntitlementsSlotSHA256,
 						   strDerEntitlementsSlotSHA256,
 						   IsExecute(),
+						   pSignAsset->m_bAdhoc,
 						   strAltnateCodeDirectorySlot);
 	SlotBuildCMSSignature(pSignAsset,
 						  strCodeDirectorySlot,

--- a/common/mach-o.h
+++ b/common/mach-o.h
@@ -498,6 +498,10 @@ enum {
 	CS_SIGNER_TYPE_UNKNOWN = 0,
 	CS_SIGNER_TYPE_LEGACYVPN = 5,
 
+/*
+ * Flags that can be specified in `CS_CodeDirectory::flags`.
+ */
+	CS_SEC_CODESIGNATURE_ADHOC = 0x0002,				/* kSecCodeSignatureAdhoc */
 };
 
 #pragma pack(push, 1)

--- a/openssl.cpp
+++ b/openssl.cpp
@@ -652,6 +652,22 @@ ZSignAsset::ZSignAsset()
 	m_x509Cert = NULL;
 }
 
+bool ZSignAsset::Init(const string &strEntitlementsFile)
+{
+	bool bResult = true;
+
+	m_bAdhoc = true;
+	if (!strEntitlementsFile.empty())
+	{
+		bResult = ReadFile(strEntitlementsFile.c_str(), m_strEntitlementsData);
+		if (!bResult)
+		{
+			ZLog::Error(">>> Couldn't Read Entitlements File!\n");
+		}
+	}
+	return bResult;
+}
+
 bool ZSignAsset::Init(const string &strSignerCertFile, const string &strSignerPKeyFile, const string &strProvisionFile, const string &strEntitlementsFile, const string &strPassword)
 {
 	ReadFile(strProvisionFile.c_str(), m_strProvisionData);

--- a/openssl.h
+++ b/openssl.h
@@ -23,6 +23,9 @@ public:
 	/// can be empty.
 	bool m_bAdhoc{};
 	bool m_bSingleBinary{}; ///< `true` if signing single binary, i.e. `CS_EXECSEG_MAIN_BINARY` flag shall be set
+	/// If true, serialize a single CSSLOT_CODEDIRECTORY that uses SHA256; otherwise, use both SHA1 and SHA256 (alternate).
+	bool m_bUseSHA256Only{};
+
 	string m_strTeamId;
 	string m_strSubjectCN;
 	string m_strProvisionData;

--- a/openssl.h
+++ b/openssl.h
@@ -13,9 +13,16 @@ public:
 
 public:
 	bool GenerateCMS(const string &strCDHashData, const string &strCDHashesPlist, const string &strCodeDirectorySlotSHA1, const string &strAltnateCodeDirectorySlot256, string &strCMSOutput);
+	/// Initialize ZSignAsset for ad-hoc signing.  Entitlements may be optionally read from \p strEntitlementsFile.
+	bool Init(const string &strEntitlementsFile);
+	/// Initialize ZSignAsset object.
 	bool Init(const string &strSignerCertFile, const string &strSignerPKeyFile, const string &strProvisionFile, const string &strEntitlementsFile, const string &strPassword);
 
 public:
+	/// If true, carry out ad-hoc signature instead; in that case, `m_strTeamId` and `m_strSubjectCN`
+	/// can be empty.
+	bool m_bAdhoc{};
+	bool m_bSingleBinary{}; ///< `true` if signing single binary, i.e. `CS_EXECSEG_MAIN_BINARY` flag shall be set
 	string m_strTeamId;
 	string m_strSubjectCN;
 	string m_strProvisionData;

--- a/signing.cpp
+++ b/signing.cpp
@@ -502,10 +502,11 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 							const string &strEntitlementsSlotSHA,
 							const string &strDerEntitlementsSlotSHA,
 							bool isExecuteArch,
+							bool isAdhoc,
 							string &strOutput)
 {
 	strOutput.clear();
-	if (NULL == pCodeBase || uCodeLength <= 0 || strBundleId.empty() || strTeamId.empty())
+	if (NULL == pCodeBase || uCodeLength <= 0 || strBundleId.empty() || (strTeamId.empty() && !isAdhoc))
 	{
 		return false;
 	}
@@ -517,7 +518,7 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 	cdHeader.magic = BE(CSMAGIC_CODEDIRECTORY);
 	cdHeader.length = 0;
 	cdHeader.version = BE(uVersion);
-	cdHeader.flags = 0;
+	cdHeader.flags = isAdhoc ? BE(static_cast<uint32_t>(CS_SEC_CODESIGNATURE_ADHOC)) : 0U;
 	cdHeader.hashOffset = 0;
 	cdHeader.identOffset = 0;
 	cdHeader.nSpecialSlots = 0;
@@ -585,7 +586,7 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 	{
 		//todo
 	}
-	if (uVersion >= 0x20200)
+	if (uVersion >= 0x20200 && !strTeamId.empty())
 	{
 		uSlotLength += uTeamIDLength;
 	}
@@ -600,7 +601,9 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 	{
 		//todo
 	}
-	if (uVersion >= 0x20200)
+	// `strTeamId` may be empty for ad-hoc signature; in that case, `cdHeader.teamOffset == 0` and string
+	// data is not serialized below.
+	if (uVersion >= 0x20200 && !strTeamId.empty())
 	{
 		uHashOffset += uTeamIDLength;
 		cdHeader.teamOffset = BE(uHeaderLength + uBundleIDLength);
@@ -613,7 +616,7 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 	{
 		//todo
 	}
-	if (uVersion >= 0x20200)
+	if (uVersion >= 0x20200 && !strTeamId.empty())
 	{
 		strOutput.append(strTeamId.data(), strTeamId.size() + 1);
 	}
@@ -719,6 +722,11 @@ bool SlotBuildCMSSignature(ZSignAsset *pSignAsset,
 						   string &strOutput)
 {
 	strOutput.clear();
+	if (pSignAsset->m_bAdhoc)
+	{
+		strOutput = "\xfa\xde\x0b\x01\x00\x00\x00\x08"sv; // The empty CSSLOT_SIGNATURESLOT
+		return true;
+	}
 
 	JValue jvHashes;
 	string strCDHashesPlist;

--- a/signing.cpp
+++ b/signing.cpp
@@ -3,6 +3,8 @@
 #include "common/mach-o.h"
 #include "openssl.h"
 
+#include <string_view>
+
 static void _DERLength(string &strBlob, uint64_t uLength)
 {
 	if (uLength < 128)
@@ -163,7 +165,7 @@ bool SlotBuildRequirements(const string &strBundleID, const string &strSubjectCN
 	strOutput.clear();
 	if (strBundleID.empty() || strSubjectCN.empty())
 	{ //ldid
-		strOutput = "\xfa\xde\x0c\x01\x00\x00\x00\x0c\x00\x00\x00\x00";
+		strOutput = "\xfa\xde\x0c\x01\x00\x00\x00\x0c\x00\x00\x00\x00"sv;
 		return true;
 	}
 

--- a/signing.h
+++ b/signing.h
@@ -21,6 +21,7 @@ bool SlotBuildCodeDirectory(bool bAlternate,
 							const string &strEntitlementsSlotSHA,
 							const string &strDerEntitlementsSlotSHA,
 							bool isExecuteArch,
+							bool isAdhoc,
 							string &strOutput);
 bool SlotBuildCMSSignature(ZSignAsset *pSignAsset,
 						   const string &strCodeDirectorySlot,


### PR DESCRIPTION
This pull-request implements ad-hoc signature.  Ad-hoc signature is useful when the binaries are known to be re-signed
at some later stage.

E.g. it can be used to inject `CSSLOT_ENTITLEMENTS`, which is later picked up when doing proper re-signing.  This only requires a valid (although non-verifiable) signature.  In general, if a pipeline requires (for whatever reason) the binary to be re-signed multiple times, all except the last stage can apply ad-hoc signature.

To this end, the `zsign` executable now parses and acts on the new command line options detailed below.
```
-a, --adhoc		Perform ad-hoc signature only.
-s, --single_inplace	Re-sign a single Mach-O binary in place. (incompatible with `-o`)
-2, --sha256_only	Serialize a single code directory that uses SHA256.
```

`--adhoc` enables the use of ad-hoc signature instead.  Second, `--single-inplace` allows to re-sign a single Mach-O executable file.
Finally, `--sha256_only` forces the serialization of a single SHA256-based code directory, which becomes the principal code directory.  If this option is not specified, the default is to have a (principal) SHA1 code directory + an (alternate) SHA256 one.

## Change list
- Add basic support for ad-hoc signature
- Allow the use of a single SHA256-based code directory.  This seems to be the default in Apple's `codesign` for ad-hoc signatures.
- Parsing of the command line flags described above

## Requirements
- https://github.com/zhlynn/zsign/pull/323 must be merged first

FYI, @zhlynn.  This is the last of a series of 4 PRs; see also: https://github.com/zhlynn/zsign/pull/323, https://github.com/zhlynn/zsign/pull/324, and https://github.com/zhlynn/zsign/pull/325.