### PR TITLE
Implement the `--verbose` command line option

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -695,11 +695,6 @@ uint64_t ZTimer::PrintResult(bool bSuccess, const char *szFormatArgs, ...)
 
 int ZLog::g_nLogLevel = ZLog::E_INFO;
 
-void ZLog::SetLogLever(int nLogLevel)
-{
-	g_nLogLevel = nLogLevel;
-}
-
 void ZLog::Print(int nLevel, const char *szLog)
 {
 	if (g_nLogLevel >= nLevel)
@@ -811,9 +806,4 @@ void ZLog::DebugV(const char *szFormatArgs, ...)
 		PARSEVALIST(szFormatArgs, szLog)
 		write(STDOUT_FILENO, szLog, strlen(szLog));
 	}
-}
-
-bool ZLog::IsDebug()
-{
-	return (E_DEBUG == g_nLogLevel);
 }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -694,6 +694,7 @@ uint64_t ZTimer::PrintResult(bool bSuccess, const char *szFormatArgs, ...)
 }
 
 int ZLog::g_nLogLevel = ZLog::E_INFO;
+bool ZLog::g_bVerbose = false;
 
 void ZLog::Print(int nLevel, const char *szLog)
 {

--- a/common/common.h
+++ b/common/common.h
@@ -138,7 +138,7 @@ public:
     };
 
 public:
-    static bool IsDebug();
+    static bool IsDebug() { return (E_DEBUG == g_nLogLevel); }
     static void Print(const char *szLog);
     static void PrintV(const char *szFormatArgs, ...);
     static void Debug(const char *szLog);
@@ -153,7 +153,7 @@ public:
     static bool PrintResultV(bool bSuccess, const char *szFormatArgs, ...);
     static void Print(int nLevel, const char *szLog);
     static void PrintV(int nLevel, const char *szFormatArgs, ...);
-    static void SetLogLever(int nLogLevel);
+    static void SetLogLever(int nLogLevel) { g_nLogLevel = nLogLevel; }
 
 private:
     static int g_nLogLevel;

--- a/common/common.h
+++ b/common/common.h
@@ -139,6 +139,7 @@ public:
 
 public:
     static bool IsDebug() { return (E_DEBUG == g_nLogLevel); }
+    static bool IsVerbose() { return g_bVerbose; }
     static void Print(const char *szLog);
     static void PrintV(const char *szFormatArgs, ...);
     static void Debug(const char *szLog);
@@ -154,7 +155,9 @@ public:
     static void Print(int nLevel, const char *szLog);
     static void PrintV(int nLevel, const char *szFormatArgs, ...);
     static void SetLogLever(int nLogLevel) { g_nLogLevel = nLogLevel; }
+    static void SetVerbose(bool bVerbose) { g_bVerbose = bVerbose; }
 
 private:
     static int g_nLogLevel;
+    static bool g_bVerbose; ///< true if extra verbosity is enabled; false otherwise
 };

--- a/signing.cpp
+++ b/signing.cpp
@@ -458,7 +458,7 @@ bool SlotParseCodeDirectory(uint8_t *pSlotBase, CS_BlobIndex *pbi)
 		PrintSHASum("\t\t\t", arrSpecialSlots[i], cdHeader.hashSize, suffix);
 	}
 
-	if (ZLog::IsDebug())
+	if (ZLog::IsVerbose())
 	{
 		ZLog::Print("\tCodeSlots:\n");
 		for (uint32_t i = 0; i < LE(cdHeader.nCodeSlots); i++)
@@ -468,7 +468,7 @@ bool SlotParseCodeDirectory(uint8_t *pSlotBase, CS_BlobIndex *pbi)
 	}
 	else
 	{
-		ZLog::Print("\tCodeSlots: \tomitted. (use -d option for details)\n");
+		ZLog::Print("\tCodeSlots: \tomitted. (use --verbose option for details)\n");
 	}
 
 	SlotParseGeneralTailer(pSlotBase, uSlotLength);

--- a/zsign.cpp
+++ b/zsign.cpp
@@ -13,7 +13,7 @@
 const struct option options[] = {
     {"debug", no_argument, NULL, 'd'},
     {"force", no_argument, NULL, 'f'},
-    {"verbose", no_argument, NULL, 'v'},
+    {"verbose", no_argument, NULL, 'V'},
     {"adhoc", no_argument, NULL, 'a'},
     {"single_inplace", no_argument, NULL, 's'},
     {"sha256_only", no_argument, NULL, '2'},
@@ -48,6 +48,7 @@ int usage() {
   ZLog::Print(
       "-d, --debug\t\tGenerate debug output files. (.zsign_debug folder)\n");
   ZLog::Print("-f, --force\t\tForce sign without cache when signing folder.\n");
+  ZLog::Print("-V, --verbose\t\tEnable extra verbosity in log.\n");
   ZLog::Print("-o, --output\t\tPath to output ipa file.\n");
   ZLog::Print("-p, --password\t\tPassword for private key or p12 file.\n");
   ZLog::Print("-b, --bundle_id\t\tNew bundle id to change.\n");
@@ -94,7 +95,7 @@ int main(int argc, char *argv[]) {
 
   int opt = 0;
   int argslot = -1;
-  while (-1 != (opt = getopt_long(argc, argv, "dfvas2hc:k:m:o:ip:e:b:n:z:ql:w",
+  while (-1 != (opt = getopt_long(argc, argv, "dfVvas2hc:k:m:o:ip:e:b:n:z:ql:w",
                                   options, &argslot))) {
     switch (opt) {
     case 'd':
@@ -102,6 +103,9 @@ int main(int argc, char *argv[]) {
       break;
     case 'f':
       bForce = true;
+      break;
+    case 'V':
+      ZLog::SetVerbose(true);
       break;
     case 'c':
       strCertFile = optarg;


### PR DESCRIPTION
There was some trails of a `--verbose` option in the long option list for `getopt_long()`, but it was never implemented.

This PR provides initial implementation, and uses it to avoid dumping CodeSlot hashes if `--verbose` is not specified.  This is very convenient, e.g. if one needs to dump signature data in `.zsign_debug/` directory, while avoiding noise in stdout logging.