### PR TITLE
Add option to check if a file is signed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ options:
 -i, --install           Install ipa file using ideviceinstaller command for test.
 -t, --temp_folder       Path to temporary folder for intermediate files.
 -2, --sha256_only       Serialize a single code directory that uses SHA256.
+-C, --check             Check if the file is signed.
 -q, --quiet             Quiet operation.
 -v, --version           Shows version.
 -h, --help              Shows help (this message).

--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -234,8 +234,11 @@ bool ZArchO::IsExecute()
 bool ZArchO::IsSigned() const 
 {
 	if (NULL == m_pSignBase || m_uSignLength <= 0) {
+		ZLog::PrintV("File is not signed.\n");
 		return false;
 	}
+	
+	ZLog::PrintV("File is signed.\n");
 	return true;
 }
 

--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -231,6 +231,14 @@ bool ZArchO::IsExecute()
 	return false;
 }
 
+bool ZArchO::IsSigned() const 
+{
+	if (NULL == m_pSignBase || m_uSignLength <= 0) {
+		return false;
+	}
+	return true;
+}
+
 void ZArchO::PrintInfo()
 {
 	if (NULL == m_pHeader) {

--- a/src/archo.h
+++ b/src/archo.h
@@ -20,6 +20,7 @@ public:
 
 	void PrintInfo();
 	bool IsExecute();
+	bool IsSigned() const;
 	bool InjectDylib(bool bWeakInject, const char* szDylibFile);
 	void RemoveDylibs(set<string> setDylibs);
 	uint32_t ReallocCodeSignSpace(const string& strNewFile);

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -112,12 +112,13 @@ void ZMachO::PrintInfo()
 	}
 }
 
-void ZMachO::CheckSignature() const
+bool ZMachO::CheckSignature() const
 {
-	for (size_t i = 0; i < m_arrArchOes.size(); i++) {
-		ZArchO* archo = m_arrArchOes[i];
-		archo->IsSigned();
-	}
+	return std::all_of(m_arrArchOes.cbegin(), m_arrArchOes.cend(), 
+		[](ZArchO const * archo) {
+			return archo->IsSigned();
+		}
+	);
 }
 
 bool ZMachO::Sign(ZSignAsset* pSignAsset, bool bForce, string strBundleId, string strInfoSHA1, string strInfoSHA256, const string& strCodeResourcesData)

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -112,6 +112,14 @@ void ZMachO::PrintInfo()
 	}
 }
 
+void ZMachO::CheckSignature() const
+{
+	for (size_t i = 0; i < m_arrArchOes.size(); i++) {
+		ZArchO* archo = m_arrArchOes[i];
+		archo->IsSigned();
+	}
+}
+
 bool ZMachO::Sign(ZSignAsset* pSignAsset, bool bForce, string strBundleId, string strInfoSHA1, string strInfoSHA256, const string& strCodeResourcesData)
 {
 	if (NULL == m_pBase || m_arrArchOes.empty()) {

--- a/src/macho.h
+++ b/src/macho.h
@@ -12,7 +12,7 @@ public:
 	bool InitV(const char* szPath, ...);
 	bool Free();
 	void PrintInfo();
-	void ZMachO::CheckSignature() const;
+	bool CheckSignature() const;
 	bool Sign(ZSignAsset* pSignAsset,
 				bool bForce, 
 				string strBundleId, 

--- a/src/macho.h
+++ b/src/macho.h
@@ -12,6 +12,7 @@ public:
 	bool InitV(const char* szPath, ...);
 	bool Free();
 	void PrintInfo();
+	void ZMachO::CheckSignature() const;
 	bool Sign(ZSignAsset* pSignAsset,
 				bool bForce, 
 				string strBundleId, 

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -78,6 +78,7 @@ int main(int argc, char* argv[])
 	bool bWeakInject = false;
 	bool bAdhoc = false;
 	bool bSHA256Only = false;
+	bool bCheckSignature = false;
 	uint32_t uZipLevel = 0;
 
 	string strCertFile;

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
 
 	int opt = 0;
 	int argslot = -1;
-	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwc:k:m:o:p:e:b:n:z:l:t:r:",
+	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCc:k:m:o:p:e:b:n:z:l:t:r:",
 		options, &argslot))) {
 		switch (opt) {
 		case 'd':

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -31,6 +31,7 @@ const struct option options[] = {
 	{"temp_folder", required_argument, NULL, 't'},
 	{"sha256_only", no_argument, NULL, '2'},
 	{"install", no_argument, NULL, 'i'},
+	{"check", no_argument, NULL, 'C'},
 	{"quiet", no_argument, NULL, 'q'},
 	{"help", no_argument, NULL, 'h'},
 	{}
@@ -59,6 +60,7 @@ int usage()
 	ZLog::Print("-i, --install\t\tInstall ipa file using ideviceinstaller command for test.\n");
 	ZLog::Print("-t, --temp_folder\tPath to temporary folder for intermediate files.\n");
 	ZLog::Print("-2, --sha256_only\tSerialize a single code directory that uses SHA256.\n");
+	ZLog::Print("-C, --check\t\tCheck if the file is signed.\n");
 	ZLog::Print("-q, --quiet\t\tQuiet operation.\n");
 	ZLog::Print("-v, --version\t\tShows version.\n");
 	ZLog::Print("-h, --help\t\tShows help (this message).\n");
@@ -149,6 +151,9 @@ int main(int argc, char* argv[])
 		case '2':
 			bSHA256Only = true;
 			break;
+		case 'C':
+			bCheckSignature = true;
+			break;
 		case 'q':
 			ZLog::SetLogLever(ZLog::E_NONE);
 			break;
@@ -202,8 +207,12 @@ int main(int argc, char* argv[])
 		}
 
 		if (!bAdhoc && arrDylibFiles.empty() && (strPKeyFile.empty() || strProvFile.empty())) {
-			macho->PrintInfo();
-			return 0;
+			if (bCheckSignature) {
+				return macho->CheckSignature() ? 0 : -2;
+			} else {
+				macho->PrintInfo();
+				return 0;
+			}
 		}
 
 		ZSignAsset zsa;


### PR DESCRIPTION
This option allows to use zsign as a tool to check if the lib is signed.

Using `zsign -C <file>` will check if the file is signed and exit with a success. If one of the arch is not signed it will exit with error code -2.