### PR TITLE
Check if stat() is successful before using result

### DIFF
--- a/src/common/fs.cpp
+++ b/src/common/fs.cpp
@@ -9,8 +9,7 @@ map<void*, void*> ZFile::s_mapFiles;
 bool ZFile::IsRegularFile(const char* path)
 {
 	struct stat st = { 0 };
-	stat(path, &st);
-	return S_ISREG(st.st_mode);
+	return 0 == stat(path, &st) && S_ISREG(st.st_mode);
 }
 
 void* ZFile::MapFile(const char* path, size_t offset, size_t size, size_t* psize, bool ro)


### PR DESCRIPTION
I have encountered an issue when running `zsign` in `linux/amd64` Docker container on my Mac.

The symptoms were errors like:
```
WriteFile: Failed in fopen! ./.zsign_debug/..., No such file or directory
```

Apparently, `zsign` was not creating `.zsign_debug/` directory and its subsequent attempts to write files into this directory were failing.

The root cause is:
https://github.com/zhlynn/zsign/blob/43caac5c0b3f94ed7b5847c2038c529181b0bf11/src/common/fs.cpp#L196-L198

If `stat()` fails, then we should not read from `st`, because:
1. there is no guarantee that `stat()` has put anything meaningful into it;
2. it was not properly initialized in the first place.

I did tests with some additional debug logging and it revealed that even though `st.st_mode` was initialized with `0` (by some lucky chance) before `stat()` nevertheless after the `stat()` call it contained some non-zero value that apparently made `S_ISDIR()` think that this is a directory. As a result `zsign` assumed that `.zsign_debug/` directory already exists and   does not need to be created:
https://github.com/zhlynn/zsign/blob/43caac5c0b3f94ed7b5847c2038c529181b0bf11/src/common/fs.cpp#L208-L211

I guess the bug does not manifest itself more often just by pure luck:

1. even without explicit initialization `st` contains zeros, especially if the build is not aggressively optimized;
2. `stat()` is likely leaving `st` untouched in case of failure;
3. `S_ISDIR(0)` is `false` and it does what one would expect.