### PR TITLE
fix: permissions for files

### DIFF
--- a/src/common/fs.cpp
+++ b/src/common/fs.cpp
@@ -43,6 +43,12 @@ void* ZFile::MapFile(const char* path, size_t offset, size_t size, size_t* psize
 #else
 
 	int fd = open(path, ro ? O_RDONLY : O_RDWR);
+	if (fd <= 0) {
+		if(chmod(path, 0755) == 0) {
+			fd = open(path, ro ? O_RDONLY : O_RDWR);
+		}
+	}
+	
 	if (fd > 0) {
 		if (size <= 0) {
 			struct stat st = { 0 };


### PR DESCRIPTION
There's an issue with zsign where it fails to sign some ipas, apps that include for example some builds `OpenSSL` fail to sign because of permissions it shouldn't exactly have. This pull request solves this problem.