### PR TITLE
perf: reduce heap allocations in code directory hashing and improve I/O throughput

### DIFF
--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -697,7 +697,7 @@ bool ZArchO::InjectDylib(bool bWeakInject, const char* szDylibFile)
 	return true;
 }
 
-void ZArchO::RemoveDylibs(set<string> setDylibs)
+void ZArchO::RemoveDylibs(const set<string>& setDylibs)
 {
 	uint8_t* pLoadCommand = m_pBase + m_uHeaderSize;
 	uint32_t old_load_command_size = m_pHeader->sizeofcmds;

--- a/src/common/fs.cpp
+++ b/src/common/fs.cpp
@@ -345,7 +345,7 @@ bool ZFile::CopyFile(const char* szSrcFile, const char* szDestFile)
 	if (-1 != src_id) {
 		dest_fd = open(szDestFile, O_CREAT | O_WRONLY | O_TRUNC, 0644);
 		if (-1 != dest_fd) {
-			char buffer[4096];
+			char buffer[65536];
 			ssize_t bytes_read = read(src_id, buffer, sizeof(buffer));
 			while (bytes_read > 0) {
 				sum_readed += bytes_read;

--- a/src/common/sha.cpp
+++ b/src/common/sha.cpp
@@ -6,7 +6,6 @@ bool ZSHA::SHA1(uint8_t* data, size_t size, string& strOutput)
 {
 	strOutput.clear();
 	uint8_t hash[20];
-	memset(hash, 0, 20);
 	::SHA1(data, size, hash);
 	strOutput.append((const char*)hash, 20);
 	return true;
@@ -16,7 +15,6 @@ bool ZSHA::SHA256(uint8_t* data, size_t size, string& strOutput)
 {
 	strOutput.clear();
 	uint8_t hash[32];
-	memset(hash, 0, 32);
 	::SHA256(data, size, hash);
 	strOutput.append((const char*)hash, 32);
 	return true;
@@ -44,11 +42,13 @@ bool ZSHA::SHA1Text(const string& strData, string& strOutput)
 	string strSHASum;
 	ZSHA::SHA1(strData, strSHASum);
 
+	static const char hex_lower[] = "0123456789abcdef";
 	strOutput.clear();
-	char buf[16] = { 0 };
+	strOutput.reserve(strSHASum.size() * 2);
 	for (size_t i = 0; i < strSHASum.size(); i++) {
-		snprintf(buf, sizeof(buf), "%02x", (uint8_t)strSHASum[i]);
-		strOutput += buf;
+		uint8_t c = (uint8_t)strSHASum[i];
+		strOutput += hex_lower[c >> 4];
+		strOutput += hex_lower[c & 0x0F];
 	}
 	return (!strOutput.empty());
 }

--- a/src/common/util.cpp
+++ b/src/common/util.cpp
@@ -150,8 +150,9 @@ const char* ZUtil::GetBaseName(const char* path)
 
 int ZUtil::builtin_clzll(uint64_t x)
 {
-	//__builtin_clzll(x);
-
+#if defined(__GNUC__) || defined(__clang__)
+	return x == 0 ? 64 : __builtin_clzll(x);
+#else
 	if (x == 0) {
 		return 64;
 	}
@@ -182,4 +183,5 @@ int ZUtil::builtin_clzll(uint64_t x)
 	}
 
 	return count;
+#endif
 }

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -232,7 +232,7 @@ bool ZMachO::ReallocCodeSignSpace()
 
 		for (size_t i = 0; i < arrArches.size(); i++) {
 			size_t sSize = 0;
-			string strNewArchOFile = m_strFile + ".archo." + jvalue((int)i).as_string();
+			string strNewArchOFile = m_strFile + ".archo." + std::to_string(i);
 			uint8_t* pData = (uint8_t*)ZFile::MapFile(strNewArchOFile.c_str(), 0, 0, &sSize, true);
 			if (NULL == pData) {
 				ZFile::RemoveFile(strNewFatMachOFile.c_str());

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -211,13 +211,14 @@ bool ZSignAsset::GenerateCMS(void* pscert, void* pspkey, const string& strCDHash
 	}
 
 	// add CDHashes
+	static const char hex_upper[] = "0123456789ABCDEF";
 	string sha256;
-	char buf[16] = { 0 };
+	sha256.reserve(strAltnateCodeDirectorySlot256.size() * 2);
 	for (size_t i = 0; i < strAltnateCodeDirectorySlot256.size(); i++) {
-		snprintf(buf, sizeof(buf), "%02x", (uint8_t)strAltnateCodeDirectorySlot256[i]);
-		sha256 += buf;
+		uint8_t c = (uint8_t)strAltnateCodeDirectorySlot256[i];
+		sha256 += hex_upper[c >> 4];
+		sha256 += hex_upper[c & 0x0F];
 	}
-	transform(sha256.begin(), sha256.end(), sha256.begin(), ::toupper);
 
 	ASN1_OBJECT* obj2 = OBJ_txt2obj("1.2.840.113635.100.9.2", 1);
 	if (!obj2) {
@@ -476,11 +477,13 @@ bool ZSignAsset::GetCMSInfo(uint8_t * pCMSData, uint32_t uCMSLength, jvalue & jv
 			} else if (0 == strcmp("1.2.840.113549.1.9.4", txtobj)) { //V_ASN1_OCTET_STRING
 				ASN1_TYPE* av = X509_ATTRIBUTE_get0_type(attr, 0);
 				if (NULL != av) {
+					static const char hex_lower[] = "0123456789abcdef";
 					string strSHASum;
-					char buf[16] = { 0 };
+					strSHASum.reserve(av->value.octet_string->length * 2);
 					for (int m = 0; m < av->value.octet_string->length; m++) {
-						snprintf(buf, sizeof(buf), "%02x", (uint8_t)av->value.octet_string->data[m]);
-						strSHASum += buf;
+						uint8_t c = (uint8_t)av->value.octet_string->data[m];
+						strSHASum += hex_lower[c >> 4];
+						strSHASum += hex_lower[c & 0x0F];
 					}
 					jvOutput["attrs"]["MessageDigest"]["obj"] = txtobj;
 					jvOutput["attrs"]["MessageDigest"]["data"] = strSHASum;

--- a/src/signing.cpp
+++ b/src/signing.cpp
@@ -3,6 +3,7 @@
 #include "mach-o.h"
 #include "openssl.h"
 #include "signing.h"
+#include <openssl/sha.h>
 
 void ZSign::_DERLength(string& strBlob, uint64_t uLength)
 {
@@ -440,7 +441,7 @@ bool ZSign::SlotBuildCodeDirectory(bool bAlternate,
 		arrSpecialSlots.erase(arrSpecialSlots.begin(), itLastUsedSpecialSlot);
 	}
 
-	uint32_t uPageSize = (uint32_t)pow(2, cdHeader.pageSize);
+	uint32_t uPageSize = 1u << cdHeader.pageSize;
 	uint32_t uPages = uCodeLength / uPageSize;
 	uint32_t uRemain = uCodeLength % uPageSize;
 	uint32_t uCodeSlots = uPages + (uRemain > 0 ? 1 : 0);
@@ -468,6 +469,7 @@ bool ZSign::SlotBuildCodeDirectory(bool bAlternate,
 	uint32_t uCodeSlotsLength = uCodeSlots * cdHeader.hashSize;
 
 	uint32_t uSlotLength = uHeaderLength + uBundleIDLength + uSpecialSlotsLength + uCodeSlotsLength;
+	strOutput.reserve(uSlotLength + uTeamIDLength); // pre-allocate to avoid reallocations
 	if (uVersion >= 0x20100) {
 		//todo
 	}
@@ -508,23 +510,24 @@ bool ZSign::SlotBuildCodeDirectory(bool bAlternate,
 	if (NULL != pCodeSlotsData && (uCodeSlotsDataLength == uCodeSlots * cdHeader.hashSize)) { //use exists
 		strOutput.append((const char*)pCodeSlotsData, uCodeSlotsDataLength);
 	} else {
+		uint8_t hash[32]; // large enough for both SHA1 (20) and SHA256 (32)
 		for (uint32_t i = 0; i < uPages; i++) {
-			string strSHASum;
 			if (1 == cdHeader.hashType) {
-				ZSHA::SHA1(pCodeBase + uPageSize * i, uPageSize, strSHASum);
-			} else  {
-				ZSHA::SHA256(pCodeBase + uPageSize * i, uPageSize, strSHASum);
-			} 
-			strOutput.append(strSHASum.data(), strSHASum.size());
+				::SHA1(pCodeBase + uPageSize * i, uPageSize, hash);
+				strOutput.append((const char*)hash, 20);
+			} else {
+				::SHA256(pCodeBase + uPageSize * i, uPageSize, hash);
+				strOutput.append((const char*)hash, 32);
+			}
 		}
 		if (uRemain > 0) {
-			string strSHASum;
 			if (1 == cdHeader.hashType) {
-				ZSHA::SHA1(pCodeBase + uPageSize * uPages, uRemain, strSHASum);
+				::SHA1(pCodeBase + uPageSize * uPages, uRemain, hash);
+				strOutput.append((const char*)hash, 20);
 			} else {
-				ZSHA::SHA256(pCodeBase + uPageSize * uPages, uRemain, strSHASum);
+				::SHA256(pCodeBase + uPageSize * uPages, uRemain, hash);
+				strOutput.append((const char*)hash, 32);
 			}
-			strOutput.append(strSHASum.data(), strSHASum.size());
 		}
 	}
 


### PR DESCRIPTION
Profiled zsign while re-signing a 340MB TikTok IPA on ARM64 Linux. The signing phase was spending noticeable time on allocation overhead instead of actual SHA computation, so I went through the source and cleaned up the obvious spots.

### Changes

**signing.cpp (hot path, SlotBuildCodeDirectory):**
- The per-page hashing loop was creating a new `std::string` for every page. On a 100MB binary at 4K pages, that's roughly 25K alloc/dealloc cycles per hash type. Changed it to hash into a stack `uint8_t[32]` and append raw bytes directly.
- Swapped `pow(2, pageSize)` for `1u << pageSize`.
- Pre-reserve the output string since we already know the final size.

**sha.cpp, openssl.cpp:**
- Dropped the `memset()` calls that zero the hash buffer right before OpenSSL writes over it anyway.
- Switched the `snprintf` hex encoding loops to a static lookup table. Gets rid of the `toupper()` pass in `GenerateCMS()` too since the table already outputs uppercase.

**util.cpp:**
- Added a `__GNUC__`/`__clang__` guard to use the real `__builtin_clzll` when available. Keeps the manual fallback for MSVC.

**base64.cpp:**
- Swapped the if-else chain in `get_b64_index()` for a 256-byte lookup table.

**archo.cpp, zsign.cpp, bundle.cpp, macho.cpp:**
- `RemoveDylibs()` was taking `set<string>` by value, changed to `const&`.
- Fixed a few range-for loops that were copying strings.
- Used `std::to_string()` instead of going through `jvalue` for int-to-string.

**fs.cpp, archive.cpp:**
- Bumped copy/zip buffers from 4K to 64K.
- Replaced the per-file `malloc(512K)` + `free()` during zip extraction with a 64K stack buffer.

### Numbers

Tested on a 338MB IPA with `-z 0`:

| | old | new |
|---|---|---|
| Unzip | 3.546s | 3.562s |
| Signing | 1.822s | 1.763s |
| Archive | 3.093s | 3.082s |
| Total | 8.603s | 8.558s |

Signing phase is about 3% faster. Total time is mostly disk I/O. No signing logic or output format was changed, skipped `json.cpp` since it's not in any hot path.