### PR TITLE
feat: add -x flag for metadata and icon extraction after signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ options:
 -t, --temp_folder       Path to temporary folder for intermediate files.
 -2, --sha256_only       Serialize a single code directory that uses SHA256.
 -C, --check             Check if the file is signed.
+-x, --metadata          Extract metadata and icon to the specified directory.
 -q, --quiet             Quiet operation.
 -v, --version           Shows version.
 -h, --help              Shows help (this message).
@@ -131,6 +132,12 @@ options:
 9. Inject dylib(LC_LOAD_WEAK_DYLIB) into mach-o file.
 ```bash
 ./zsign -w -l "@executable_path/demo.dylib" demo.app/execute
+```
+
+10. Sign ipa and extract metadata (app info + icon) to a directory.
+```bash
+./zsign -k dev.p12 -p 123 -m dev.prov -x ./metadata -o output.ipa demo.ipa
+# writes ./metadata/metadata.json and ./metadata/<hash>.png
 ```
 
 ## How to sign quickly?

--- a/build/windows/vs2022/zsign/zsign.vcxproj
+++ b/build/windows/vs2022/zsign/zsign.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="..\..\..\..\src\openssl.cpp" />
     <ClCompile Include="..\..\..\..\src\signing.cpp" />
     <ClCompile Include="..\..\..\..\src\zsign.cpp" />
+    <ClCompile Include="..\..\..\..\src\metadata.cpp" />
     <ClCompile Include="src\getopt.cpp" />
     <ClCompile Include="src\iconv.cpp" />
   </ItemGroup>

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,0 +1,129 @@
+#include "metadata.h"
+#include "json.h"
+#include "sha.h"
+#include "fs.h"
+#include "util.h"
+
+static void GetIconNames(jvalue& jvInfo, vector<string>& arrNames)
+{
+	if (jvInfo.has("CFBundleIcons")) {
+		jvalue& jvIcons = jvInfo["CFBundleIcons"];
+		if (jvIcons.has("CFBundlePrimaryIcon")) {
+			jvalue& jvPrimary = jvIcons["CFBundlePrimaryIcon"];
+			jvalue& jvFiles = jvPrimary["CFBundleIconFiles"];
+			if (jvFiles.is_array()) {
+				for (size_t i = 0; i < jvFiles.size(); i++) {
+					string strName = jvFiles[i];
+					if (!strName.empty()) {
+						arrNames.push_back(strName);
+					}
+				}
+			}
+		}
+	}
+
+	if (arrNames.empty() && jvInfo.has("CFBundleIconFiles")) {
+		jvalue& jvIconFiles = jvInfo["CFBundleIconFiles"];
+		if (jvIconFiles.is_array()) {
+			for (size_t i = 0; i < jvIconFiles.size(); i++) {
+				string strName = jvIconFiles[i];
+				if (!strName.empty()) {
+					arrNames.push_back(strName);
+				}
+			}
+		}
+	}
+
+	if (arrNames.empty()) {
+		string strSingleIcon = jvInfo["CFBundleIconFile"];
+		if (!strSingleIcon.empty()) {
+			arrNames.push_back(strSingleIcon);
+		}
+	}
+}
+
+static bool FindLargestIcon(const string& strAppFolder, const vector<string>& arrIconNames, string& strBestPath)
+{
+	int64_t nBestSize = 0;
+	ZFile::EnumFolder(strAppFolder.c_str(), false, NULL, [&](bool bFolder, const string& strPath) {
+		if (bFolder) {
+			return false;
+		}
+		string strBaseName = ZUtil::GetBaseName(strPath.c_str());
+		for (const string& strPrefix : arrIconNames) {
+			if (0 == strncmp(strBaseName.c_str(), strPrefix.c_str(), strPrefix.size())) {
+				int64_t nSize = ZFile::GetFileSize(strPath.c_str());
+				if (nSize > nBestSize) {
+					nBestSize = nSize;
+					strBestPath = strPath;
+				}
+				break;
+			}
+		}
+		return false;
+	});
+	return (nBestSize > 0);
+}
+
+bool GetMetadata(const string& strAppFolder, const string& strOutputDir, const string& strIpaFile)
+{
+	string strInfoPlistData;
+	string strInfoPlistPath = strAppFolder + "/Info.plist";
+	if (!ZFile::ReadFile(strInfoPlistPath.c_str(), strInfoPlistData)) {
+		return ZLog::ErrorV(">>> GetMetadata: Can't read %s\n", strInfoPlistPath.c_str());
+	}
+
+	jvalue jvInfo;
+	jvInfo.read_plist(strInfoPlistData);
+
+	string strAppName = jvInfo["CFBundleDisplayName"];
+	if (strAppName.empty()) {
+		strAppName = jvInfo["CFBundleName"].as_cstr();
+	}
+
+	string strAppVersion = jvInfo["CFBundleShortVersionString"];
+	if (strAppVersion.empty()) {
+		strAppVersion = jvInfo["CFBundleVersion"].as_cstr();
+	}
+
+	string strBundleId = jvInfo["CFBundleIdentifier"];
+
+	// extract icon
+	string strIconName;
+	vector<string> arrIconNames;
+	GetIconNames(jvInfo, arrIconNames);
+
+	string strBestIconPath;
+	if (!arrIconNames.empty() && FindLargestIcon(strAppFolder, arrIconNames, strBestIconPath)) {
+		string strHash;
+		ZSHA::SHA1Text(strBestIconPath, strHash);
+		strIconName = strHash + ".png";
+		ZFile::CopyFile(strBestIconPath.c_str(), (strOutputDir + "/" + strIconName).c_str());
+	}
+
+	// ipa file info
+	int64_t nIpaSize = 0;
+	string strFileName;
+	if (!strIpaFile.empty()) {
+		nIpaSize = ZFile::GetFileSize(strIpaFile.c_str());
+		strFileName = ZUtil::GetBaseName(strIpaFile.c_str());
+	}
+
+	// write json
+	jvalue jvMeta;
+	jvMeta["AppName"] = strAppName;
+	jvMeta["AppVersion"] = strAppVersion;
+	jvMeta["AppBundleIdentifier"] = strBundleId;
+	jvMeta["AppSize"] = (int)nIpaSize;
+	jvMeta["IconName"] = strIconName.empty() ? "" : strIconName;
+	jvMeta["FileName"] = strFileName;
+	jvMeta["Timestamp"] = (int)ZUtil::GetUnixStamp();
+
+	string strMetaPath = strOutputDir + "/metadata.json";
+	if (!jvMeta.style_write_to_file("%s", strMetaPath.c_str())) {
+		return ZLog::ErrorV(">>> GetMetadata: Can't write %s\n", strMetaPath.c_str());
+	}
+
+	ZLog::PrintV(">>> Metadata:\t%s\n", strMetaPath.c_str());
+	return true;
+}

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "common.h"
+
+bool GetMetadata(const string& strAppFolder, const string& strOutputDir, const string& strIpaFile);

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -4,6 +4,7 @@
 #include "openssl.h"
 #include "timer.h"
 #include "archive.h"
+#include "metadata.h"
 
 #ifdef _WIN32
 #include "common_win32.h"
@@ -33,6 +34,7 @@ const struct option options[] = {
 	{"install", no_argument, NULL, 'i'},
 	{"check", no_argument, NULL, 'C'},
 	{"quiet", no_argument, NULL, 'q'},
+	{"metadata", required_argument, NULL, 'x'},
 	{"help", no_argument, NULL, 'h'},
 	{}
 };
@@ -62,6 +64,7 @@ int usage()
 	ZLog::Print("-2, --sha256_only\tSerialize a single code directory that uses SHA256.\n");
 	ZLog::Print("-C, --check\t\tCheck if the file is signed.\n");
 	ZLog::Print("-q, --quiet\t\tQuiet operation.\n");
+	ZLog::Print("-x, --metadata\t\tExtract metadata and icon to the specified directory.\n");
 	ZLog::Print("-v, --version\t\tShows version.\n");
 	ZLog::Print("-h, --help\t\tShows help (this message).\n");
 
@@ -91,11 +94,12 @@ int main(int argc, char* argv[])
 	string strDisplayName;
 	string strEntitleFile;
 	vector<string> arrDylibFiles;
+	string strMetadataDir;
 	string strTempFolder = ZFile::GetTempFolder();
 
 	int opt = 0;
 	int argslot = -1;
-	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCc:k:m:o:p:e:b:n:z:l:t:r:",
+	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCc:k:m:o:p:e:b:n:z:l:t:r:x:",
 		options, &argslot))) {
 		switch (opt) {
 		case 'd':
@@ -157,6 +161,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'q':
 			ZLog::SetLogLever(ZLog::E_NONE);
+			break;
+		case 'x':
+			strMetadataDir = ZFile::GetFullPath(optarg);
 			break;
 		case 'v': {
 			printf("version: %s\n", ZSIGN_VERSION);
@@ -222,7 +229,7 @@ int main(int argc, char* argv[])
 		}
 
 		if (!arrDylibFiles.empty()) {
-			for (string dyLibFile : arrDylibFiles) {
+			for (const string& dyLibFile : arrDylibFiles) {
 				if (!macho->InjectDylib(bWeakInject, dyLibFile.c_str())) {
 					return -1;
 				}
@@ -291,6 +298,10 @@ int main(int argc, char* argv[])
 				bRet = false;
 			} else {
 				atimer.PrintResult(true, ">>> Archive OK! (%s)", ZFile::GetFileSizeString(strOutputFile.c_str()).c_str());
+				if (bRet && !strMetadataDir.empty()) {
+					ZFile::CreateFolder(strMetadataDir.c_str());
+					GetMetadata(bundle.m_strAppFolder, strMetadataDir, strOutputFile);
+				}
 			}
 		} else {
 			ZLog::Error(">>> Can't find payload directory!\n");


### PR DESCRIPTION
Adds `-x <dir>` to extract app metadata and the primary icon to a directory after signing, before archiving. 

New files:
- `src/metadata.h` + `src/metadata.cpp` - plist parsing, icon search, json output

The icon search walks `CFBundleIcons -> CFBundlePrimaryIcon -> CFBundleIconFiles`, falls back to the legacy `CFBundleIconFiles` and `CFBundleIconFile` keys. Picks the largest matching PNG and copies it to the output dir named by its SHA1 hash.

Output (`metadata.json`):
```json
{
  "AppName": "TikTok",
  "AppVersion": "43.4.0",
  "AppBundleIdentifier": "com.zhiliaoapp.musically",
  "AppSize": 656987365,
  "IconName": "3b1b71b04000e4698a5b40fb027945b22ffbb3d0.png",
  "FileName": "signed.ipa",
  "Timestamp": 1772751111
}
```

Usage:
```bash
zsign -k key.p12 -p pass -m dev.prov -x ./out -o signed.ipa app.ipa
```

Tested on a 338MB TikTok IPA, works fine.