### PR TITLE
fix: increase ReallocCodeSignSpace buffer from 16K to 32K

### DIFF
--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -585,7 +585,7 @@ uint32_t ZArchO::ReallocCodeSignSpace(const string& strNewFile)
 {
 	ZFile::RemoveFile(strNewFile.c_str());
 
-	uint32_t uNewLength = m_uCodeLength + ZUtil::ByteAlign(((m_uCodeLength / 4096) + 1) * (20 + 32), 4096) + 16384; //16K May Be Enough
+	uint32_t uNewLength = m_uCodeLength + ZUtil::ByteAlign(((m_uCodeLength / 4096) + 1) * (20 + 32), 4096) + 32768; //32K Should Be Enough
 	if (NULL == m_pLinkEditSegment || uNewLength <= m_uLength) {
 		return 0;
 	}


### PR DESCRIPTION
The 16KB fixed buffer for CMS signature blob is insufficient for some unsigned binaries with small code sections. For example, a Flutter app's Runner binary (~32 code pages) needs 20916 bytes of CodeSignature space, but the old formula only allocates 20480 bytes (4096 hash space + 16384 fixed buffer), causing "No enough CodeSignature space" errors during signing.

Increasing the buffer to 32KB provides sufficient headroom for larger CMS blobs with varying certificate chain sizes.