### PR TITLE
feat: add -D/--rm_dylib to remove injected dylibs

### DIFF
--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -377,6 +377,17 @@ bool ZBundle::SignNode(jvalue& jvNode)
 				bForceSign = true;
 			}
 		}
+		if (!m_setRemoveDylibs.empty()) {
+			macho.RemoveDylibs(m_setRemoveDylibs);
+			for (const string& name : m_setRemoveDylibs) {
+				string baseName = name;
+				if (baseName.find("@executable_path/") == 0) {
+					baseName = baseName.substr(17);
+				}
+				ZFile::RemoveFileV("%s/%s", m_strAppFolder.c_str(), baseName.c_str());
+			}
+			bForceSign = true;
+		}
 	}
 
 	if (m_pSignAssets) {
@@ -525,6 +536,7 @@ bool ZBundle::SignFolder(ZSignAsset* pSignAsset,
 							const string& strBundleVersion,
 							const string& strDisplayName,
 							const vector<string>& arrInjectDylibs,
+							const vector<string>& arrRemoveDylibNames,
 							bool bForce,
 							bool bWeakInject,
 							bool bEnableCache,
@@ -534,6 +546,10 @@ bool ZBundle::SignFolder(ZSignAsset* pSignAsset,
 	m_pSignAsset = pSignAsset;
 	m_bWeakInject = bWeakInject;
 	m_bRemoveProvision = bRemoveProvision;
+	m_setRemoveDylibs.clear();
+	for (const string& name : arrRemoveDylibNames) {
+		m_setRemoveDylibs.insert("@executable_path/" + name);
+	}
 	if (NULL == m_pSignAsset) {
 		return false;
 	}
@@ -622,11 +638,12 @@ bool ZBundle::SignFolder(list<ZSignAsset>* pSignAssets,
 						const string& strBundleVersion,
 						const string& strDisplayName,
 						const vector<string>& arrInjectDylibs,
+						const vector<string>& arrRemoveDylibNames,
 						bool bForce,
 						bool bWeakInject,
 						bool bEnableCache,
 						bool bRemoveProvision)
 {
 	m_pSignAssets = pSignAssets;
-	return SignFolder(&m_pSignAssets->front(), strFolder, strBundleId, strBundleVersion, strDisplayName, arrInjectDylibs, bForce, bWeakInject, bEnableCache, bRemoveProvision);
+	return SignFolder(&m_pSignAssets->front(), strFolder, strBundleId, strBundleVersion, strDisplayName, arrInjectDylibs, arrRemoveDylibNames, bForce, bWeakInject, bEnableCache, bRemoveProvision);
 }

--- a/src/bundle.h
+++ b/src/bundle.h
@@ -4,6 +4,7 @@
 #include "openssl.h"
 #include <vector>
 #include <list>
+#include <set>
 
 class ZBundle
 {
@@ -17,6 +18,7 @@ public:
 					const string& strBundleVersion,
 					const string& strDisplayName,
 					const vector<string>& arrDylibFiles,
+					const vector<string>& arrRemoveDylibNames,
 					bool bForce,
 					bool bWeakInject,
 					bool bEnableCache,
@@ -28,6 +30,7 @@ public:
 					const string& strBundleVersion,
 					const string& strDisplayName,
 					const vector<string>& arrDylibFiles,
+					const vector<string>& arrRemoveDylibNames,
 					bool bForce,
 					bool bWeakInject,
 					bool bEnableCache,
@@ -55,6 +58,7 @@ private:
 	ZSignAsset*		m_pSignAsset;
 	list<ZSignAsset>*	m_pSignAssets;
 	vector<string>	m_arrInjectDylibs;
+	set<string>		m_setRemoveDylibs;
 
 public:
 	string			m_strAppFolder;

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -271,3 +271,10 @@ bool ZMachO::InjectDylib(bool bWeakInject, const char* szDylibFile)
 	ZLog::Warn(">>> Success!\n");
 	return true;
 }
+
+void ZMachO::RemoveDylibs(const set<string>& setDylibs)
+{
+	for (size_t i = 0; i < m_arrArchOes.size(); i++) {
+		m_arrArchOes[i]->RemoveDylibs(setDylibs);
+	}
+}

--- a/src/macho.h
+++ b/src/macho.h
@@ -20,6 +20,7 @@ public:
 				string strInfoSHA256, 
 				const string& strCodeResourcesData);
 	bool InjectDylib(bool bWeakInject, const char* szDylibFile);
+	void RemoveDylibs(const set<string>& setDylibs);
 
 private:
 	bool OpenFile(const char* szPath);

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -29,6 +29,7 @@ const struct option options[] = {
 	{"output", required_argument, NULL, 'o'},
 	{"zip_level", required_argument, NULL, 'z'},
 	{"dylib", required_argument, NULL, 'l'},
+	{"rm_dylib", required_argument, NULL, 'D'},
 	{"weak", no_argument, NULL, 'w'},
 	{"temp_folder", required_argument, NULL, 't'},
 	{"sha256_only", no_argument, NULL, '2'},
@@ -60,6 +61,7 @@ int usage()
 	ZLog::Print("-e, --entitlements\tNew entitlements to change.\n");
 	ZLog::Print("-z, --zip_level\t\tCompressed level when output the ipa file. (0-9)\n");
 	ZLog::Print("-l, --dylib\t\tPath to inject dylib file. Use -l multiple time to inject multiple dylib files at once.\n");
+	ZLog::Print("-D, --rm_dylib\t\tName of dylib to remove. Use -D multiple times to remove multiple dylibs at once.\n");
 	ZLog::Print("-w, --weak\t\tInject dylib as LC_LOAD_WEAK_DYLIB.\n");
 	ZLog::Print("-i, --install\t\tInstall ipa file using ideviceinstaller command for test.\n");
 	ZLog::Print("-t, --temp_folder\tPath to temporary folder for intermediate files.\n");
@@ -99,12 +101,13 @@ int main(int argc, char* argv[])
 	string strDisplayName;
 	string strEntitleFile;
 	vector<string> arrDylibFiles;
+	vector<string> arrRemoveDylibNames;
 	string strMetadataDir;
 	string strTempFolder = ZFile::GetTempFolder();
 
 	int opt = 0;
 	int argslot = -1;
-	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCRc:k:m:o:p:e:b:n:z:l:t:r:x:",
+	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCRc:k:m:o:p:e:b:n:z:l:D:t:r:x:",
 		options, &argslot))) {
 		switch (opt) {
 		case 'd':
@@ -143,6 +146,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'l':
 			arrDylibFiles.push_back(ZFile::GetFullPath(optarg));
+			break;
+		case 'D':
+			arrRemoveDylibNames.push_back(optarg);
 			break;
 		case 'i':
 			bInstall = true;
@@ -302,9 +308,9 @@ int main(int argc, char* argv[])
 				zsaList.pop_back();
 			}
 		}
-		bRet = bundle.SignFolder(&zsaList, strFolder, strBundleId, strBundleVersion, strDisplayName, arrDylibFiles, bForce, bWeakInject, bEnableCache, bRemoveProvision);
+		bRet = bundle.SignFolder(&zsaList, strFolder, strBundleId, strBundleVersion, strDisplayName, arrDylibFiles, arrRemoveDylibNames, bForce, bWeakInject, bEnableCache, bRemoveProvision);
 	} else {
-		bRet = bundle.SignFolder(&zsa, strFolder, strBundleId, strBundleVersion, strDisplayName, arrDylibFiles, bForce, bWeakInject, bEnableCache, bRemoveProvision);
+		bRet = bundle.SignFolder(&zsa, strFolder, strBundleId, strBundleVersion, strDisplayName, arrDylibFiles, arrRemoveDylibNames, bForce, bWeakInject, bEnableCache, bRemoveProvision);
 	}
 	atimer.PrintResult(bRet, ">>> Signed %s!", bRet ? "OK" : "Failed");
 


### PR DESCRIPTION
Fixes #255

turns out `ZArchO::RemoveDylibs` was already in the codebase but never wired up to the CLI. this PR exposes it as `-D`/`--rm_dylib`.

it removes the `LC_LOAD_DYLIB` (or `LC_LOAD_WEAK_DYLIB`) load command from the binary AND deletes the dylib file from the app folder, then re-signs.

use `-D` multiple times to remove multiple dylibs at once, same way `-l` works for injection.

```
zsign -k key.p12 -m dev.prov -D tweak1.dylib -D tweak2.dylib -o clean.ipa modded.ipa
```

tested with [xash3d-fwgs IPA](https://github.com/FWGS/xash3d-fwgs/releases/download/continuous/xash3d-fwgs-ios-arm64.ipa) — removed `libmenu.dylib`:

**before (16.33 MB):**
```
@rpath/SDL2.framework/SDL2
@executable_path/libmenu.dylib    <-- present
/System/Library/Frameworks/Foundation.framework/Foundation
...
```

**after -D libmenu.dylib (15.68 MB):**
```
@rpath/SDL2.framework/SDL2
/System/Library/Frameworks/Foundation.framework/Foundation
...
```

`libmenu.dylib` gone from binary load commands + file deleted from the IPA. signed OK.