### PR TITLE
fix: handle non-Mach-O .dylib files during signing

### DIFF
--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -121,9 +121,7 @@ bool ZBundle::GetObjectsToSign(const string& strFolder, jvalue& jvInfo)
 			return false;
 		}
 		bool bMachO = false;
-		if (ZFile::IsPathSuffix(strPath, ".dylib")) {
-			bMachO = true;
-		} else {
+		{
 			FILE* fp = NULL;
 #ifdef _WIN32
 			fopen_s(&fp, strPath.c_str(), "rb");
@@ -301,7 +299,7 @@ bool ZBundle::SignNode(jvalue& jvNode)
 					return false;
 				}
 			} else {
-				return false;
+				ZLog::WarnV(">>> Warning: Skipping non-Mach-O file: \t%s\n", strFile.c_str());
 			}
 		}
 	}

--- a/src/macho.cpp
+++ b/src/macho.cpp
@@ -83,7 +83,7 @@ bool ZMachO::OpenFile(const char* szPath)
 				return false;
 			}
 		} else {
-			ZLog::ErrorV(">>> Invalid mach-o file (2)!\n");
+			ZLog::ErrorV(">>> Invalid mach-o file (magic: 0x%08x)!\n", magic);
 			return false;
 		}
 	}


### PR DESCRIPTION
Fixes #368

## Problem

Signing fails with `Invalid mach-o file (2)!` on IPAs containing non-Mach-O `.dylib` files  specifically `SubstrateInjection.dylib` inside CydiaSubstrate.framework in tweaked apps like VibeTok.

## Root Cause

`GetObjectsToSign()` blindly marked every `.dylib` as Mach-O without checking magic bytes. When `SignNode()` tried to parse these stub files, it hit invalid magic and aborted the entire signing process.

## Fix

- Validate magic bytes for **all** files including `.dylib`  no more blind assumptions
- Warn and skip non-Mach-O files instead of aborting the whole signing process
- Print actual magic bytes in error message for easier debugging