### PR TITLE
feat: add -U/--rm_uisd to remove UISupportedDevices

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ options:
 -C, --check             Check if the file is signed.
 -x, --metadata          Extract metadata and icon to the specified directory.
 -R, --rm_provision      Remove mobileprovision file after signing.
+-U, --rm_uisd           Remove UISupportedDevices from Info.plist.
 -q, --quiet             Quiet operation.
 -v, --version           Shows version.
 -h, --help              Shows help (this message).
@@ -140,6 +141,11 @@ options:
 ```bash
 ./zsign -k dev.p12 -p 123 -m dev.prov -x ./metadata -o output.ipa demo.ipa
 # writes ./metadata/metadata.json and ./metadata/<hash>.png
+```
+
+11. Remove UISupportedDevices to allow the app on any device.
+```bash
+./zsign -k dev.p12 -p 123 -m dev.prov -U -o output.ipa demo.ipa
 ```
 
 ## How to sign quickly?

--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -12,6 +12,7 @@ ZBundle::ZBundle()
 	m_bForceSign = false;
 	m_bWeakInject = false;
 	m_bRemoveProvision = false;
+	m_bRemoveUISupportedDevices = false;
 }
 
 bool ZBundle::FindAppFolder(const string& strFolder, string& strAppFolder)
@@ -568,6 +569,21 @@ bool ZBundle::ModifyBundleInfo(const string& strBundleId, const string& strBundl
 	return true;
 }
 
+void ZBundle::ApplyAppModifications()
+{
+
+	if (m_bRemoveUISupportedDevices) {
+		jvalue jvInfo;
+		jvInfo.read_plist_from_file("%s/Info.plist", m_strAppFolder.c_str());
+		if (jvInfo.has("UISupportedDevices")) {
+			jvInfo.erase("UISupportedDevices");
+			jvInfo.style_write_plist_to_file("%s/Info.plist", m_strAppFolder.c_str());
+			m_bForceSign = true;
+			ZLog::Print(">>> Removed UISupportedDevices\n");
+		}
+	}
+}
+
 bool ZBundle::SignFolder(ZSignAsset* pSignAsset,
 							const string& strFolder,
 							const string& strBundleId,
@@ -596,6 +612,8 @@ bool ZBundle::SignFolder(ZSignAsset* pSignAsset,
 		ZLog::ErrorV(">>> Can't find app folder! %s\n", strFolder.c_str());
 		return false;
 	}
+
+	ApplyAppModifications();
 
 	if (!strBundleId.empty() || !strDisplayName.empty() || !strBundleVersion.empty()) {
 		m_bForceSign = true;

--- a/src/bundle.h
+++ b/src/bundle.h
@@ -60,6 +60,10 @@ private:
 	vector<string>	m_arrInjectDylibs;
 	set<string>		m_setRemoveDylibs;
 
+private:
+	void ApplyAppModifications();
+
 public:
+	bool		m_bRemoveUISupportedDevices;
 	string			m_strAppFolder;
 };

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -38,6 +38,7 @@ const struct option options[] = {
 	{"quiet", no_argument, NULL, 'q'},
 	{"metadata", required_argument, NULL, 'x'},
 	{"rm_provision", no_argument, NULL, 'R'},
+	{"rm_uisd", no_argument, NULL, 'U'},
 	{"help", no_argument, NULL, 'h'},
 	{}
 };
@@ -70,6 +71,7 @@ int usage()
 	ZLog::Print("-q, --quiet\t\tQuiet operation.\n");
 	ZLog::Print("-x, --metadata\t\tExtract metadata and icon to the specified directory.\n");
 	ZLog::Print("-R, --rm_provision\tRemove mobileprovision file after signing.\n");
+	ZLog::Print("-U, --rm_uisd\t\tRemove UISupportedDevices from Info.plist.\n");
 	ZLog::Print("-v, --version\t\tShows version.\n");
 	ZLog::Print("-h, --help\t\tShows help (this message).\n");
 
@@ -88,6 +90,7 @@ int main(int argc, char* argv[])
 	bool bSHA256Only = false;
 	bool bCheckSignature = false;
 	bool bRemoveProvision = false;
+	bool bRemoveUISupportedDevices = false;
 	uint32_t uZipLevel = 0;
 
 	string strCertFile;
@@ -107,7 +110,7 @@ int main(int argc, char* argv[])
 
 	int opt = 0;
 	int argslot = -1;
-	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCRc:k:m:o:p:e:b:n:z:l:D:t:r:x:",
+	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCRUc:k:m:o:p:e:b:n:z:l:D:t:r:x:",
 		options, &argslot))) {
 		switch (opt) {
 		case 'd':
@@ -179,6 +182,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'R':
 			bRemoveProvision = true;
+			break;
+		case 'U':
+			bRemoveUISupportedDevices = true;
 			break;
 		case 'v': {
 			printf("version: %s\n", ZSIGN_VERSION);
@@ -298,6 +304,8 @@ int main(int argc, char* argv[])
 	//sign
 	atimer.Reset();
 	ZBundle bundle;
+	bundle.m_bRemoveUISupportedDevices = bRemoveUISupportedDevices;
+
 	bool bRet;
 	if (arrProvFiles.size() > 1) {
 		list<ZSignAsset> zsaList;


### PR DESCRIPTION
removes the `UISupportedDevices` key from Info.plist so the app can run on any device (iPhone, iPad, etc) instead of being locked to specific models.

tested: added `UISupportedDevices` to an IPA, ran `zsign -U`, verified the key is gone from the output plist.

fixes #255 (partial)