### PR TITLE
Fix signatures rejected by macOS codesign --verify

### DIFF
--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -379,14 +379,27 @@ bool ZArchO::BuildCodeSignature(ZSignAsset* pSignAsset,
 
 	uint64_t uExecSegFlags = 0;
 	if (MH_EXECUTE == m_uFileType) {
-		if (pSignAsset->m_bAdhoc || pSignAsset->m_bSingleBinary) {
-			uExecSegFlags = CS_EXECSEG_MAIN_BINARY;
-		}
+		// MAIN_BINARY must be set on the main executable for any signature flavour
+		// (ad-hoc, single-binary, or full CMS). Without it, codesign --verify on
+		// macOS rejects the signature as "invalid".
+		uExecSegFlags = CS_EXECSEG_MAIN_BINARY;
 	}
 
-	if (NULL != strstr(strEntitlementsSlot.data() + 8, "<key>get-task-allow</key>")) {
-		// TODO: Check if get-task-allow is actually set to true
-		uExecSegFlags |= CS_EXECSEG_MAIN_BINARY | CS_EXECSEG_ALLOW_UNSIGNED;
+	// ALLOW_UNSIGNED is a development-only flag. It must be set *only* when
+	// get-task-allow is actually true (debug build), not merely present in
+	// the entitlements plist. Distribution profiles include
+	// <key>get-task-allow</key><false/> and must keep this flag cleared — Apple
+	// codesign never sets ALLOW_UNSIGNED for such signatures.
+	if (!strEntitlementsSlot.empty()) {
+		const char* pEnt = strEntitlementsSlot.data() + 8; // skip blob header
+		const char* pKey = strstr(pEnt, "<key>get-task-allow</key>");
+		if (NULL != pKey) {
+			const char* pTrue  = strstr(pKey, "<true/>");
+			const char* pFalse = strstr(pKey, "<false/>");
+			if (NULL != pTrue && (NULL == pFalse || pTrue < pFalse)) {
+				uExecSegFlags |= CS_EXECSEG_ALLOW_UNSIGNED;
+			}
+		}
 	}
 
 	string strCodeDirectorySlot;

--- a/src/signing.cpp
+++ b/src/signing.cpp
@@ -662,20 +662,56 @@ bool ZSign::SlotBuildCMSSignature(ZSignAsset* pSignAsset,
 		return true;
 	}
 
+	// The CMS "cdhashes" plist (attr 1.2.840.113635.100.9.1) and the "CDHashes2"
+	// attribute (1.2.840.113635.100.9.2) must only contain hashes of CodeDirectory
+	// blobs that actually exist in the signature. When only one CodeDirectory is
+	// serialized (SHA256-only mode), emitting hashes for a non-existent alternate
+	// CD breaks Apple's code signature verification with errSecCSSignatureFailed
+	// (`codesign --verify` reports "code or signature have been modified"):
+	// verification computes hashes of the real CDs and finds the second entry
+	// doesn't match any actual CD.
+	//
+	// Format rules derived from Apple codesign output:
+	// - cdhashes plist: one entry per CD, value = first 20 bytes of the CD's
+	//   "best" hash. For dual-hash builds (SHA1+SHA256) the primary CD uses SHA1
+	//   directly (20 bytes) and the alternate uses SHA256 truncated to 20.
+	//   For SHA256-only builds the single entry uses SHA256 truncated to 20.
+	// - CDHashes2 attribute: full hash (32 bytes for SHA256) of each CD wrapped
+	//   in `SEQUENCE { OID sha256, OCTET STRING hash }`. The current
+	//   GenerateCMS() implementation consumes a single `strAltnateCodeDirectorySlot256`
+	//   string for this attribute — when there is no alternate CD we pass the
+	//   SHA256 of the primary CD instead of SHA256(empty).
+	const bool bHasAlternate = !strAltnateCodeDirectorySlot.empty();
+
 	jvalue jvHashes;
 	string strCDHashesPlist;
-	string strCodeDirectorySlotSHA1;
-	string strAltnateCodeDirectorySlot256;
+	string strCodeDirectorySlotSHA1;   // SHA1 of primary CD (used by CMS detached content & dual-hash plist[0])
+	string strPrimaryCD_SHA256;        // SHA256 of primary CD (used in SHA256-only mode)
+	string strAltnateCD_SHA256;        // SHA256 of alternate CD (dual-hash mode only)
 	ZSHA::SHA1(strCodeDirectorySlot, strCodeDirectorySlotSHA1);
-	ZSHA::SHA256(strAltnateCodeDirectorySlot, strAltnateCodeDirectorySlot256);
+	ZSHA::SHA256(strCodeDirectorySlot, strPrimaryCD_SHA256);
+	if (bHasAlternate) {
+		ZSHA::SHA256(strAltnateCodeDirectorySlot, strAltnateCD_SHA256);
+	}
 
-	size_t cdHashSize = strCodeDirectorySlotSHA1.size();
-	jvHashes["cdhashes"][0].assign_data(strCodeDirectorySlotSHA1.data(), cdHashSize);
-	jvHashes["cdhashes"][1].assign_data(strAltnateCodeDirectorySlot256.data(), cdHashSize);
+	// 20-byte (truncated) hashes for the CDHashes plist.
+	const size_t kPlistHashLen = 20;
+	if (bHasAlternate) {
+		jvHashes["cdhashes"][0].assign_data(strCodeDirectorySlotSHA1.data(), kPlistHashLen);
+		jvHashes["cdhashes"][1].assign_data(strAltnateCD_SHA256.data(), kPlistHashLen);
+	} else {
+		// SHA256-only: single CD, use its SHA256 truncated to 20 bytes.
+		jvHashes["cdhashes"][0].assign_data(strPrimaryCD_SHA256.data(), kPlistHashLen);
+	}
 	jvHashes.style_write_plist(strCDHashesPlist);
 
+	// Full SHA256 hash to embed in the CDHashes2 signed attribute. In SHA256-only
+	// mode this must be the SHA256 of the primary CD, not SHA256 of an empty
+	// alternate — the latter is rejected by Apple's verifier.
+	const string& strCDHashes2 = bHasAlternate ? strAltnateCD_SHA256 : strPrimaryCD_SHA256;
+
 	string strCMSData;
-	if (!pSignAsset->GenerateCMS(strCodeDirectorySlot, strCDHashesPlist, strCodeDirectorySlotSHA1, strAltnateCodeDirectorySlot256, strCMSData)) {
+	if (!pSignAsset->GenerateCMS(strCodeDirectorySlot, strCDHashesPlist, strCodeDirectorySlotSHA1, strCDHashes2, strCMSData)) {
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

Two bugs caused zsign-produced signatures to be rejected by `codesign --verify` on macOS with `invalid signature (code or signature have been modified)` / `errSecCSSignatureFailed` (-67061), even though iOS / TrollStore / AltStore / Sideloadly accepted them.

Both are fixed in one commit.

### 1. `execSegFlags` — `archo.cpp`

`CS_EXECSEG_ALLOW_UNSIGNED` (0x10) was set whenever the entitlements plist contained a `<key>get-task-allow</key>` entry, **regardless of its value**. Distribution provisioning profiles ship `<key>get-task-allow</key><false/>`, so zsign produced distribution binaries with `execSegFlags=0x11` instead of `0x1`.

`CS_EXECSEG_MAIN_BINARY` was also only set for ad-hoc / single-binary signatures, but Apple codesign always sets it on main executables.

Fix: always set `MAIN_BINARY` for `MH_EXECUTE`; only set `ALLOW_UNSIGNED` when `get-task-allow` is actually `<true/>`.

### 2. CMS `CDHashes` / `CDHashes2` attributes — `signing.cpp`

In SHA256-only mode (`-2`) there is no alternate CodeDirectory, but the previous code still computed `SHA256` of the empty alternate slot and emitted it as:
- a second entry in the `cdhashes` plist (attr `1.2.840.113635.100.9.1`)
- the value of the `CDHashes2` attribute (`1.2.840.113635.100.9.2`)

Apple's verifier hashes the real CDs present in the signature and compares against these attributes. The phantom `SHA256("")` = `e3b0c44298fc1c14…` entry matched no CD, so verification failed.

Fix: when the alternate CD is empty, emit a single `cdhashes` plist entry containing `SHA256(primary CD)` truncated to 20 bytes, and use full `SHA256(primary CD)` for `CDHashes2`. When dual-hash signing (SHA1+SHA256) is used the original two-entry layout is preserved.

## Before / after

Tested by re-signing an IPA with `zsign -2 -k dist.p12 -m prof.mobileprovision`:

| | before | after |
|---|---|---|
| `codesign --verify` | `invalid signature (code or signature have been modified)` | `valid on disk, satisfies its Designated Requirement` |
| `Authority` | `(unavailable)` | `iPhone Distribution: … → Apple WWDR CA → Apple Root CA` |
| `Info.plist` | `not bound` | `entries=N` |
| `Executable Segment flags` | `0x11` | `0x1` |
| `spctl --assess` origin | *(missing)* | `iPhone Distribution: …` |

iOS installation paths (AltStore / TrollStore / Sideloadly) continue to work as before.

## Test plan

- [x] Sign an iOS app (distribution cert + `<false/>` get-task-allow). `codesign --verify` now passes on macOS.
- [x] Sign a second IPA with a different distribution cert / team — verify passes.
- [x] `spctl --assess --type execute` shows the correct `origin=…` line.
- [ ] Test signing with `get-task-allow=<true/>` (dev build) — should still produce `execSegFlags=0x11` as before.
- [ ] Test dual-hash (SHA1+SHA256) mode — `cdhashes` plist should still have two entries as before.