### PR TITLE
Fix codesign --verify failures on M1-M4 Macs and modern iOS

### DIFF
--- a/src/archo.cpp
+++ b/src/archo.cpp
@@ -379,14 +379,27 @@ bool ZArchO::BuildCodeSignature(ZSignAsset* pSignAsset,
 
 	uint64_t uExecSegFlags = 0;
 	if (MH_EXECUTE == m_uFileType) {
-		if (pSignAsset->m_bAdhoc || pSignAsset->m_bSingleBinary) {
-			uExecSegFlags = CS_EXECSEG_MAIN_BINARY;
-		}
+		// MAIN_BINARY must be set on the main executable for any signature flavour
+		// (ad-hoc, single-binary, or full CMS). Without it, codesign --verify on
+		// macOS rejects the signature as "invalid".
+		uExecSegFlags = CS_EXECSEG_MAIN_BINARY;
 	}
 
-	if (NULL != strstr(strEntitlementsSlot.data() + 8, "<key>get-task-allow</key>")) {
-		// TODO: Check if get-task-allow is actually set to true
-		uExecSegFlags |= CS_EXECSEG_MAIN_BINARY | CS_EXECSEG_ALLOW_UNSIGNED;
+	// ALLOW_UNSIGNED is a development-only flag. It must be set *only* when
+	// get-task-allow is actually true (debug build), not merely present in
+	// the entitlements plist. Distribution profiles include
+	// <key>get-task-allow</key><false/> and must keep this flag cleared — Apple
+	// codesign never sets ALLOW_UNSIGNED for such signatures.
+	if (!strEntitlementsSlot.empty()) {
+		const char* pEnt = strEntitlementsSlot.data() + 8; // skip blob header
+		const char* pKey = strstr(pEnt, "<key>get-task-allow</key>");
+		if (NULL != pKey) {
+			const char* pTrue  = strstr(pKey, "<true/>");
+			const char* pFalse = strstr(pKey, "<false/>");
+			if (NULL != pTrue && (NULL == pFalse || pTrue < pFalse)) {
+				uExecSegFlags |= CS_EXECSEG_ALLOW_UNSIGNED;
+			}
+		}
 	}
 
 	string strCodeDirectorySlot;

--- a/src/signing.cpp
+++ b/src/signing.cpp
@@ -662,20 +662,56 @@ bool ZSign::SlotBuildCMSSignature(ZSignAsset* pSignAsset,
 		return true;
 	}
 
+	// The CMS "cdhashes" plist (attr 1.2.840.113635.100.9.1) and the "CDHashes2"
+	// attribute (1.2.840.113635.100.9.2) must only contain hashes of CodeDirectory
+	// blobs that actually exist in the signature. When only one CodeDirectory is
+	// serialized (SHA256-only mode), emitting hashes for a non-existent alternate
+	// CD breaks Apple's code signature verification with errSecCSSignatureFailed
+	// (`codesign --verify` reports "code or signature have been modified"):
+	// verification computes hashes of the real CDs and finds the second entry
+	// doesn't match any actual CD.
+	//
+	// Format rules derived from Apple codesign output:
+	// - cdhashes plist: one entry per CD, value = first 20 bytes of the CD's
+	//   "best" hash. For dual-hash builds (SHA1+SHA256) the primary CD uses SHA1
+	//   directly (20 bytes) and the alternate uses SHA256 truncated to 20.
+	//   For SHA256-only builds the single entry uses SHA256 truncated to 20.
+	// - CDHashes2 attribute: full hash (32 bytes for SHA256) of each CD wrapped
+	//   in `SEQUENCE { OID sha256, OCTET STRING hash }`. The current
+	//   GenerateCMS() implementation consumes a single `strAltnateCodeDirectorySlot256`
+	//   string for this attribute — when there is no alternate CD we pass the
+	//   SHA256 of the primary CD instead of SHA256(empty).
+	const bool bHasAlternate = !strAltnateCodeDirectorySlot.empty();
+
 	jvalue jvHashes;
 	string strCDHashesPlist;
-	string strCodeDirectorySlotSHA1;
-	string strAltnateCodeDirectorySlot256;
+	string strCodeDirectorySlotSHA1;   // SHA1 of primary CD (used by CMS detached content & dual-hash plist[0])
+	string strPrimaryCD_SHA256;        // SHA256 of primary CD (used in SHA256-only mode)
+	string strAltnateCD_SHA256;        // SHA256 of alternate CD (dual-hash mode only)
 	ZSHA::SHA1(strCodeDirectorySlot, strCodeDirectorySlotSHA1);
-	ZSHA::SHA256(strAltnateCodeDirectorySlot, strAltnateCodeDirectorySlot256);
+	ZSHA::SHA256(strCodeDirectorySlot, strPrimaryCD_SHA256);
+	if (bHasAlternate) {
+		ZSHA::SHA256(strAltnateCodeDirectorySlot, strAltnateCD_SHA256);
+	}
 
-	size_t cdHashSize = strCodeDirectorySlotSHA1.size();
-	jvHashes["cdhashes"][0].assign_data(strCodeDirectorySlotSHA1.data(), cdHashSize);
-	jvHashes["cdhashes"][1].assign_data(strAltnateCodeDirectorySlot256.data(), cdHashSize);
+	// 20-byte (truncated) hashes for the CDHashes plist.
+	const size_t kPlistHashLen = 20;
+	if (bHasAlternate) {
+		jvHashes["cdhashes"][0].assign_data(strCodeDirectorySlotSHA1.data(), kPlistHashLen);
+		jvHashes["cdhashes"][1].assign_data(strAltnateCD_SHA256.data(), kPlistHashLen);
+	} else {
+		// SHA256-only: single CD, use its SHA256 truncated to 20 bytes.
+		jvHashes["cdhashes"][0].assign_data(strPrimaryCD_SHA256.data(), kPlistHashLen);
+	}
 	jvHashes.style_write_plist(strCDHashesPlist);
 
+	// Full SHA256 hash to embed in the CDHashes2 signed attribute. In SHA256-only
+	// mode this must be the SHA256 of the primary CD, not SHA256 of an empty
+	// alternate — the latter is rejected by Apple's verifier.
+	const string& strCDHashes2 = bHasAlternate ? strAltnateCD_SHA256 : strPrimaryCD_SHA256;
+
 	string strCMSData;
-	if (!pSignAsset->GenerateCMS(strCodeDirectorySlot, strCDHashesPlist, strCodeDirectorySlotSHA1, strAltnateCodeDirectorySlot256, strCMSData)) {
+	if (!pSignAsset->GenerateCMS(strCodeDirectorySlot, strCDHashesPlist, strCodeDirectorySlotSHA1, strCDHashes2, strCMSData)) {
 		return false;
 	}
 

--- a/src/signing.cpp
+++ b/src/signing.cpp
@@ -3,6 +3,7 @@
 #include "mach-o.h"
 #include "openssl.h"
 #include "signing.h"
+#include <algorithm>
 #include <openssl/sha.h>
 
 void ZSign::_DERLength(string& strBlob, uint64_t uLength)
@@ -25,7 +26,7 @@ string ZSign::_DER(const jvalue& data)
 	if (data.is_bool()) {
 		strOutput.append(1, 0x01);
 		strOutput.append(1, 1);
-		strOutput.append(1, data.as_bool() ? 1 : 0);
+		strOutput.append(1, data.as_bool() ? (char)0xff : (char)0x00);
 	} else if (data.is_int()) {
 		uint64_t uVal = data.as_int64();
 		strOutput.append(1, 0x02);
@@ -51,24 +52,27 @@ string ZSign::_DER(const jvalue& data)
 		_DERLength(strOutput, strArray.size());
 		strOutput += strArray;
 	} else if (data.is_object()) {
-		string strDict;
 		vector<string> arrKeys;
 		data.get_keys(arrKeys);
+		std::sort(arrKeys.begin(), arrKeys.end());
+
+		string strDict;
 		for (size_t i = 0; i < arrKeys.size(); i++) {
 			string& strKey = arrKeys[i];
 			string strVal = _DER(data[strKey]);
 
+			string strEntry;
+			strEntry.append(1, 0x0c);
+			_DERLength(strEntry, strKey.size());
+			strEntry += strKey;
+			strEntry += strVal;
+
 			strDict.append(1, 0x30);
-			_DERLength(strDict, (2 + strKey.size() + strVal.size()));
-
-			strDict.append(1, 0x0c);
-			_DERLength(strDict, strKey.size());
-			strDict += strKey;
-
-			strDict += strVal;
+			_DERLength(strDict, strEntry.size());
+			strDict += strEntry;
 		}
 
-		strOutput.append(1, 0x31);
+		strOutput.append(1, (char)0xb0);
 		_DERLength(strOutput, strDict.size());
 		strOutput += strDict;
 	} else if (data.is_double()) {
@@ -317,7 +321,20 @@ bool ZSign::SlotBuildDerEntitlements(const string& strEntitlements, string& strO
 	jvalue jvInfo;
 	jvInfo.read_plist(strEntitlements);
 
-	string strRawEntitlementsData = _DER(jvInfo);
+	string strInnerDict = _DER(jvInfo);
+
+	string strVersion;
+	strVersion.append(1, 0x02);
+	strVersion.append(1, 0x01);
+	strVersion.append(1, 0x01);
+
+	string strBody = strVersion + strInnerDict;
+
+	string strRawEntitlementsData;
+	strRawEntitlementsData.append(1, (char)0x70);
+	_DERLength(strRawEntitlementsData, strBody.size());
+	strRawEntitlementsData += strBody;
+
 	uint32_t uMagic = BE((uint32_t)CSMAGIC_EMBEDDED_DER_ENTITLEMENTS);
 	uint32_t uLength = BE((uint32_t)strRawEntitlementsData.size() + 8);
 

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -40,6 +40,7 @@ const struct option options[] = {
 	{"weak", no_argument, NULL, 'w'},
 	{"temp_folder", required_argument, NULL, 't'},
 	{"sha256_only", no_argument, NULL, '2'},
+	{"legacy_sha1", no_argument, NULL, 'L'},
 	{"install", no_argument, NULL, 'i'},
 	{"check", no_argument, NULL, 'C'},
 	{"quiet", no_argument, NULL, 'q'},
@@ -77,7 +78,8 @@ int usage()
 	ZLog::Print("-w, --weak\t\tInject dylib as LC_LOAD_WEAK_DYLIB.\n");
 	ZLog::Print("-i, --install\t\tInstall ipa file using ideviceinstaller command for test.\n");
 	ZLog::Print("-t, --temp_folder\tPath to temporary folder for intermediate files.\n");
-	ZLog::Print("-2, --sha256_only\tSerialize a single code directory that uses SHA256.\n");
+	ZLog::Print("-2, --sha256_only\t(Deprecated, now the default.) Kept for backward compatibility.\n");
+	ZLog::Print("-L, --legacy_sha1\tEmit a dual SHA1+SHA256 CodeDirectory for iOS <= 10 compatibility.\n");
 	ZLog::Print("-C, --check\t\tCheck certificate validity and OCSP revocation status.\n");
 	ZLog::Print("-q, --quiet\t\tQuiet operation.\n");
 	ZLog::Print("-x, --metadata\t\tExtract metadata and icon to the specified directory.\n");
@@ -102,7 +104,7 @@ int main(int argc, char* argv[])
 	bool bInstall = false;
 	bool bWeakInject = false;
 	bool bAdhoc = false;
-	bool bSHA256Only = false;
+	bool bSHA256Only = true;
 	bool bCheckSignature = false;
 	bool bRemoveProvision = false;
 	bool bEnableDocuments = false;
@@ -129,7 +131,7 @@ int main(int argc, char* argv[])
 
 	int opt = 0;
 	int argslot = -1;
-	while (-1 != (opt = getopt_long(argc, argv, "dfva2hiqwCRSEWUc:k:m:o:p:e:b:n:z:l:D:t:r:x:M:",
+	while (-1 != (opt = getopt_long(argc, argv, "dfva2LhiqwCRSEWUc:k:m:o:p:e:b:n:z:l:D:t:r:x:M:",
 		options, &argslot))) {
 		switch (opt) {
 		case 'd':
@@ -188,7 +190,11 @@ int main(int argc, char* argv[])
 			strTempFolder = ZFile::GetFullPath(optarg);
 			break;
 		case '2':
+			// Kept for backward compatibility; SHA256-only is the default now.
 			bSHA256Only = true;
+			break;
+		case 'L':
+			bSHA256Only = false;
 			break;
 		case 'C':
 			bCheckSignature = true;


### PR DESCRIPTION
## Summary

zsign-produced signatures are currently rejected by Apple Silicon (M1-M4) Macs and recent iOS/iPadOS/visionOS versions with:

- `invalid signature (code or signature have been modified)`
- `Authority=(unavailable)`
- `warning: binary contains an invalid entitlements blob. The OS will ignore these entitlements.`
- `Info.plist=not bound`

The binaries still load on older iOS, TrollStore, AltStore, and Sideloadly, but current Apple `codesign --verify` rejects them. This PR contains two independent fixes that together make the output pass `codesign --verify` on macOS 15 / M4 and install cleanly on iOS 17/18.

## What this PR changes

### 1. `execSegFlags` no longer forces `ALLOW_UNSIGNED` for distribution-profile apps (commit `a98b1ce`)

`ALLOW_UNSIGNED (0x10)` was set whenever the entitlements plist contained a `<key>get-task-allow</key>` entry, regardless of its value. Distribution provisioning profiles ship `<key>get-task-allow</key><false/>`, so zsign was producing distribution binaries with `ALLOW_UNSIGNED` in `execSegFlags`. macOS rejects that combination. The check now parses the boolean value.

### 2. DER entitlements blob is emitted in Apple's canonical form, and SHA256-only is the default (commit `fe1750d`, M4+ / modern iOS fix)

Two sub-fixes, both required for modern codesign:

**DER encoding.** `_DER()` emitted plist dicts as `SET (0x31) OF SEQUENCE { UTF8String key, value }` with unsorted keys and `BOOLEAN true = 0x01`, and `SlotBuildDerEntitlements()` wrapped that directly in the `fade7172` blob header. The canonical format that current macOS/iOS accepts (extracted from an Apple-signed reference IPA) is:

```
[APPLICATION 16] (0x70) IMPLICIT SEQUENCE {
    version   INTEGER (= 1),
    entries   [CONTEXT 16] (0xb0) IMPLICIT SET OF Entitlement
}
Entitlement ::= SEQUENCE { key UTF8String, value ANY }
```

with entries sorted lexicographically by key and `BOOLEAN true = 0xff` (DER canonical). Anything else triggers `invalid entitlements blob`.

**Dual SHA1+SHA256 default.** zsign defaulted to emitting both a primary SHA1 CodeDirectory and an alternate SHA256 one. M-series Macs (including M4) and recent iOS no longer accept SHA1 CodeDirectories — they pick SHA1 as primary, fail verification, and report `Authority=(unavailable)` / `invalid signature`. SHA1 dual-hashing was only needed for iOS ≤ 10.

- Default is now `bSHA256Only = true`.
- New opt-in flag `-L` / `--legacy_sha1` restores the dual-hash behaviour for users still targeting iOS ≤ 10.
- `-2` / `--sha256_only` is kept as a no-op for backward compatibility.

## Before / after

Reference test IPA signed with `./zsign -k cert.p12 -p ... -m prof.mobileprovision -o out.ipa in.ipa`.

**Before** (current master, on M4 Mac):

```
$ codesign --verify --verbose=4 Payload/Foo.app
Payload/Foo.app: invalid signature (code or signature have been modified)

$ codesign -dvvv Payload/Foo.app
Authority=(unavailable)
Info.plist=not bound
warning: binary contains an invalid entitlements blob. The OS will ignore these entitlements.
Hash choices=sha1,sha256
```

**After** (this PR, on M4 Mac):

```
$ codesign --verify --verbose=4 Payload/Foo.app
Payload/Foo.app: valid on disk
Payload/Foo.app: satisfies its Designated Requirement

$ codesign -dvv Payload/Foo.app
Authority=iPhone Distribution: ... (TEAMID)
Authority=Apple Worldwide Developer Relations Certification Authority
Authority=Apple Root CA
Info.plist entries=47
Hash choices=sha256
# no "invalid entitlements blob" warning
```

## Files touched

- `src/archo.cpp` — fix `execSegFlags` handling of `get-task-allow` (boolean, not presence).
- `src/signing.cpp` — `_DER()`, `SlotBuildDerEntitlements()`.
- `src/zsign.cpp` — `bSHA256Only` default, new `-L` / `--legacy_sha1` flag, updated `--help`.

## Test plan

- [x] Build on macOS 15 / arm64 (clang++ / `build/macos/Makefile`).
- [x] Build on Ubuntu 22.04 / x86_64 via Docker (`build/linux/Makefile`).
- [x] Sign a real third-party IPA on an M4 Mac using a real Apple Development / Distribution identity + provisioning profile and verify:
  - `codesign --verify --verbose=4` → `valid on disk` + `satisfies its Designated Requirement`.
  - `codesign -dvvv` → full Apple certificate chain, `Hash choices=sha256`, no `invalid entitlements blob` warning.
- [x] Sanity-check existing flags (`-k`, `-m`, `-p`, `-o`, `-b`, `-z`, …) are unchanged.
- [x] `-2` / `--sha256_only` still accepted as a no-op.
- [x] `-L` / `--legacy_sha1` produces the old SHA1+SHA256 dual CodeDirectory for iOS ≤ 10 targets.

## When to use `-L` / `--legacy_sha1`

Only when the target device must run iOS ≤ 10 (iPhone 5/5c and earlier). In that mode the signature will again be rejected by `codesign --verify` on M-series Macs — that is inherent to dual-hash SHA1+SHA256 and unfixable without dropping SHA1.