### PR TITLE
fix: seal embedded.mobileprovision after writing it in multi-profile …

### DIFF
--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -371,6 +371,29 @@ bool ZBundle::SignNode(jvalue& jvNode)
 		}
 	}
 
+	// In multi-profile mode, select the provisioning profile matching this
+	// bundle's id and write it to disk BEFORE generating CodeResources, so the
+	// seal covers the final embedded.mobileprovision (otherwise codesign reports
+	// "a sealed resource is missing or invalid" for embedded.mobileprovision).
+	// This also sets m_pSignAsset so macho.Sign() below uses the matching
+	// certificate/entitlements for this bundle (main app vs. extension).
+	if (m_pSignAssets) {
+		auto endsWith = [](const string& str, const string& suffix) {
+			return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
+		};
+
+		for (auto it = m_pSignAssets->rbegin(); it != m_pSignAssets->rend(); ++it) {
+			m_pSignAsset = &(*it);
+			if (endsWith(m_pSignAsset->m_strApplicationId, strBundleId)) {
+				if (!ZFile::WriteFileV(m_pSignAsset->m_strProvData, "%s/%s/embedded.mobileprovision", m_strAppFolder.c_str(), strFolder.c_str())) {
+					ZLog::ErrorV(">>> Can't write embedded.mobileprovision!\n");
+					return false;
+				}
+				break;
+			}
+		}
+	}
+
 	ZFile::CreateFolderV("%s/_CodeSignature", strBaseFolder.c_str());
 	string strCodeResFile = strBaseFolder + "/_CodeSignature/CodeResources";
 
@@ -414,40 +437,6 @@ bool ZBundle::SignNode(jvalue& jvNode)
 	if (!ZFile::WriteFile(strCodeResFile.c_str(), strCodeResData)) {
 		ZLog::ErrorV("\tWriting CodeResources failed! %s\n", strCodeResFile.c_str());
 		return false;
-	}
-
-	if (m_pSignAssets) {
-		auto endsWith = [](const string& str, const string& suffix) {
-			return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
-		};
-
-		for (auto it = m_pSignAssets->rbegin(); it != m_pSignAssets->rend(); ++it) {
-			m_pSignAsset = &(*it);
-			if (endsWith(m_pSignAsset->m_strApplicationId, strBundleId)) {
-				if (!ZFile::WriteFileV(m_pSignAsset->m_strProvData, "%s/%s/embedded.mobileprovision", m_strAppFolder.c_str(), strFolder.c_str())) {
-					ZLog::ErrorV(">>> Can't write embedded.mobileprovision!\n");
-					return false;
-				}
-				break;
-			}
-		}
-	}
-
-	if (m_pSignAssets) {
-		auto endsWith = [](const string& str, const string& suffix) {
-			return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
-		};
-
-		for (auto it = m_pSignAssets->rbegin(); it != m_pSignAssets->rend(); ++it) {
-			m_pSignAsset = &(*it);
-			if (endsWith(m_pSignAsset->m_strApplicationId, strBundleId)) {
-				if (!ZFile::WriteFileV(m_pSignAsset->m_strProvData, "%s/%s/embedded.mobileprovision", m_strAppFolder.c_str(), strFolder.c_str())) {
-					ZLog::ErrorV(">>> Can't write embedded.mobileprovision!\n");
-					return false;
-				}
-				break;
-			}
-		}
 	}
 
 	if (!macho.Sign(m_pSignAsset, bForceSign, strBundleId, strInfoSHA1, strInfoSHA256, strCodeResData)) {


### PR DESCRIPTION
…mode

In multi-profile signing (multiple -m profiles for apps with extensions), SignNode() generated the CodeResources seal *before* overwriting each bundle's embedded.mobileprovision with the id-matched profile. The seal therefore captured the stale profile, and `codesign --verify --deep --strict` rejected every such bundle with:

    a sealed resource is missing or invalid
    file modified: .../embedded.mobileprovision

Move the profile-selection/write ahead of GenerateCodeResources so the seal covers the final file, and drop a duplicated copy of the block. The single-profile path already wrote the profile before sealing (in SignFolder), so it was unaffected; this only fixes the multi-profile extension path.