### PR TITLE
Fix CLI option parsing and harden file/zip reads

### DIFF
--- a/src/common/archive.cpp
+++ b/src/common/archive.cpp
@@ -217,11 +217,14 @@ bool Zip::_ReadFileFromZip(void* hZip, const string& strPath, const string& strR
 	if (NULL != pbuff) {
 		int32_t nReaded = unzReadCurrentFile(hZip, pbuff, uBufSize);
 		while (nReaded > 0) {
-			if (nReaded != fwrite(pbuff, 1, nReaded, fp)) {
+			if ((size_t)nReaded != fwrite(pbuff, 1, (size_t)nReaded, fp)) {
 				bRet = false;
 				break;
 			}
 			nReaded = unzReadCurrentFile(hZip, pbuff, uBufSize);
+		}
+		if (nReaded < 0) {
+			bRet = false;
 		}
 		free(pbuff);
 	} else {

--- a/src/common/fs.cpp
+++ b/src/common/fs.cpp
@@ -43,13 +43,13 @@ void* ZFile::MapFile(const char* path, size_t offset, size_t size, size_t* psize
 #else
 
 	int fd = open(path, ro ? O_RDONLY : O_RDWR);
-	if (fd <= 0) {
+	if (fd < 0) {
 		if(chmod(path, 0755) == 0) {
 			fd = open(path, ro ? O_RDONLY : O_RDWR);
 		}
 	}
 	
-	if (fd > 0) {
+	if (fd >= 0) {
 		if (size <= 0) {
 			struct stat st = { 0 };
 			fstat(fd, &st);

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -23,7 +23,7 @@
 const struct option options[] = {
 	{"debug", no_argument, NULL, 'd'},
 	{"force", no_argument, NULL, 'f'},
-	{"verbose", no_argument, NULL, 'V'},
+	{"version", no_argument, NULL, 'v'},
 	{"adhoc", no_argument, NULL, 'a'},
 	{"cert", required_argument, NULL, 'c'},
 	{"pkey", required_argument, NULL, 'k'},
@@ -234,7 +234,7 @@ int main(int argc, char* argv[])
 			break;
 		}
 
-		ZLog::DebugV(">>> Option:\t-%c, %s\n", opt, optarg);
+		ZLog::DebugV(">>> Option:\t-%c, %s\n", opt, optarg ? optarg : "");
 	}
 
 	if (optind >= argc) {


### PR DESCRIPTION
## Summary
- fix the documented `--version` long option so it maps to the existing version handler
- avoid passing a null `optarg` into debug logging for flag-only options
- treat file descriptor 0 as a valid POSIX open result in `ZFile::MapFile`
- fail zip extraction when `unzReadCurrentFile` returns a read error instead of reporting success

## Verification
- rebuilt successfully with `make clean && make` in `build/macos`
- verified `./bin/zsign --version` now returns version output with exit code 0
- verified `./bin/zsign ./bin/zsign` still works when stdin is closed, covering the `fd == 0` path
