### PR TITLE
Fix certificate type detection and ASN.1 failure handling

### DIFF
--- a/src/certcheck.cpp
+++ b/src/certcheck.cpp
@@ -153,6 +153,19 @@ static X509* ResolveIssuer(X509* cert)
 	return NULL;
 }
 
+static X509* FindIssuerInChain(STACK_OF(X509)* certs, X509* cert)
+{
+	if (!certs || !cert) return NULL;
+	for (int i = 0; i < sk_X509_num(certs); i++) {
+		X509* issuer = sk_X509_value(certs, i);
+		if (issuer && X509_check_issued(issuer, cert) == X509_V_OK) {
+			X509_up_ref(issuer);
+			return issuer;
+		}
+	}
+	return NULL;
+}
+
 // ─── file type detection ────────────────────────────────────────────
 
 enum CertFileType {
@@ -191,9 +204,16 @@ static CertFileType DetectFileType(const string& path, const string& data)
 			return CERT_FILE_MACHO;
 		if (data.find("<?xml") != string::npos && data.find("</plist>") != string::npos)
 			return CERT_FILE_PROVISION;
-		if (d[0] == 0x30 && data.size() > 500) return CERT_FILE_P12;
-		if (d[0] == 0x30) return CERT_FILE_CER;
 		if (data.find("-----BEGIN") != string::npos) return CERT_FILE_PEM;
+		if (d[0] == 0x30) {
+			const uint8_t* p = (const uint8_t*)data.data();
+			PKCS12* p12 = d2i_PKCS12(NULL, &p, (long)data.size());
+			if (p12) {
+				PKCS12_free(p12);
+				return CERT_FILE_P12;
+			}
+			return CERT_FILE_CER;
+		}
 	}
 	return CERT_FILE_UNKNOWN;
 }
@@ -695,7 +715,7 @@ int CheckCertificate(const string& strFilePath, const string& strPassword)
 	bool expired = (daysLeft < 0);
 
 	X509* issuer = NULL;
-	if (ca && sk_X509_num(ca) > 0) { issuer = sk_X509_value(ca, 0); X509_up_ref(issuer); }
+	if (ca && sk_X509_num(ca) > 0) issuer = FindIssuerInChain(ca, cert);
 	if (!issuer) issuer = ResolveIssuer(cert);
 
 	int retCode = 0;

--- a/src/openssl.cpp
+++ b/src/openssl.cpp
@@ -283,27 +283,35 @@ void* ZSignAsset::GenerateASN1Type(const string& value)
 	char* genstr = NULL;
 	BIO* ldapbio = BIO_new(BIO_s_mem());
 	CONF* cnf = NCONF_new(NULL);
-
-	if (cnf == NULL) {
-		ZLog::Error(">>> NCONF_new failed\n");
-		BIO_free(ldapbio);
-	}
+	ASN1_TYPE* ret = NULL;
 	string a = "asn1=SEQUENCE:A\n[A]\nC=OBJECT:sha256\nB=FORMAT:HEX,OCT:" + value + "\n";
-	int code = BIO_puts(ldapbio, a.c_str());
-	if (NCONF_load_bio(cnf, ldapbio, &errline) <= 0) {
-		BIO_free(ldapbio);
-		NCONF_free(cnf);
-		ZLog::PrintV(">>> NCONF_load_bio failed %d\n", errline);
+
+	if (NULL == ldapbio || NULL == cnf) {
+		ZLog::Error(">>> NCONF_new failed\n");
+		goto cleanup;
 	}
-	BIO_free(ldapbio);
+	if (BIO_puts(ldapbio, a.c_str()) <= 0) {
+		ZLog::Error(">>> BIO_puts failed\n");
+		goto cleanup;
+	}
+	if (NCONF_load_bio(cnf, ldapbio, &errline) <= 0) {
+		ZLog::PrintV(">>> NCONF_load_bio failed %d\n", errline);
+		goto cleanup;
+	}
 	genstr = NCONF_get_string(cnf, "default", "asn1");
 
 	if (genstr == NULL) {
 		ZLog::Error(">>> NCONF_get_string failed\n");
-		NCONF_free(cnf);
+		goto cleanup;
 	}
-	ASN1_TYPE* ret = ASN1_generate_nconf(genstr, cnf);
-	NCONF_free(cnf);
+	ret = ASN1_generate_nconf(genstr, cnf);
+	if (NULL == ret) {
+		ZLog::Error(">>> ASN1_generate_nconf failed\n");
+	}
+
+cleanup:
+	if (ldapbio) BIO_free(ldapbio);
+	if (cnf) NCONF_free(cnf);
 	return ret;
 }
 
@@ -470,9 +478,15 @@ bool ZSignAsset::GenerateCMS(void* pscert, void* pspkey, const string& strCDHash
 	}
 
 	X509_ATTRIBUTE* attr = X509_ATTRIBUTE_new();
+	if (!attr) {
+		return CMSError();
+	}
 	X509_ATTRIBUTE_set1_object(attr, obj2);
 
 	ASN1_TYPE* type_256 = (ASN1_TYPE*)GenerateASN1Type(sha256);
+	if (!type_256) {
+		return CMSError();
+	}
 	X509_ATTRIBUTE_set1_data(attr, V_ASN1_SEQUENCE,
 		ASN1_STRING_get0_data(type_256->value.asn1_string), ASN1_STRING_length(type_256->value.asn1_string));
 	int addHashSHA = CMS_signed_add1_attr(si, attr);


### PR DESCRIPTION
## Summary
- detect PKCS#12 inputs by attempting real PKCS#12 parsing instead of classifying every large DER blob as a P12 file
- choose the actual issuer from the CA chain bundled in a P12 before performing OCSP checks
- harden the ASN.1 generation failure path so CMS signing returns an error instead of dereferencing invalid pointers

## Verification
- rebuilt successfully with `make clean && make` in `build/macos`
- verified `./bin/zsign -C /tmp/zsign-cert-noext` now reports the file as `DER` instead of misclassifying it as `PKCS#12`
