### PR TITLE
build: link system zlib when SYSTEM_MINIZIP is set

### DIFF
--- a/build/linux/Makefile
+++ b/build/linux/Makefile
@@ -49,6 +49,7 @@ endif
 INCLUDES = -I../../src -I../../src/common
 INCLUDES += $(OPENSSL_INCLUDE) $(shell pkg-config --cflags $(MINIZIP_PC))
 LIBS += $(shell pkg-config --libs $(MINIZIP_PC))
+LIBS += $(shell pkg-config --libs zlib)
 ZLIB_OBJS =
 MINIZIP_OBJS =
 endif

--- a/build/macos/Makefile
+++ b/build/macos/Makefile
@@ -49,6 +49,7 @@ endif
 INCLUDES = -I../../src -I../../src/common
 INCLUDES += $(OPENSSL_INCLUDE) $(shell pkg-config --cflags $(MINIZIP_PC))
 LIBS += $(shell pkg-config --libs $(MINIZIP_PC))
+LIBS += $(shell pkg-config --libs zlib)
 ZLIB_OBJS =
 MINIZIP_OBJS =
 endif


### PR DESCRIPTION
metadata.cpp calls zlib's inflate/compress APIs directly, but the SYSTEM_MINIZIP path disables the vendored ZLIB_OBJS and only links $(MINIZIP_PC). minizip-ng.pc lists zlib as Requires.private, so pkg-config --libs minizip-ng does not emit -lz and the final link fails with undefined zlib symbols. Link system zlib explicitly.