### PR TITLE
Harden zip extraction and install execution paths

### DIFF
--- a/src/common/archive.cpp
+++ b/src/common/archive.cpp
@@ -238,19 +238,28 @@ bool Zip::_ReadFileFromZip(void* hZip, const string& strPath, const string& strR
 
 static bool _IsPathSafe(const string& strPath)
 {
-	if (strPath.empty() || strPath[0] == '/') {
+	if (strPath.empty()) {
+		return false;
+	}
+
+	string strNormalized = strPath;
+	ZUtil::StringReplace(strNormalized, "\\", "/");
+	if (strNormalized[0] == '/' || strNormalized[0] == '\\') {
+		return false;
+	}
+	if (string::npos != strNormalized.find(':')) {
 		return false;
 	}
 
 	size_t start = 0;
-	size_t len = strPath.size();
+	size_t len = strNormalized.size();
 	while (start < len) {
-		size_t end = strPath.find('/', start);
+		size_t end = strNormalized.find('/', start);
 		if (end == string::npos) {
 			end = len;
 		}
 		size_t compLen = end - start;
-		if (compLen == 2 && strPath[start] == '.' && strPath[start + 1] == '.') {
+		if (compLen == 2 && strNormalized[start] == '.' && strNormalized[start + 1] == '.') {
 			return false;
 		}
 		start = end + 1;

--- a/src/common/fs.cpp
+++ b/src/common/fs.cpp
@@ -43,12 +43,6 @@ void* ZFile::MapFile(const char* path, size_t offset, size_t size, size_t* psize
 #else
 
 	int fd = open(path, ro ? O_RDONLY : O_RDWR);
-	if (fd < 0) {
-		if(chmod(path, 0755) == 0) {
-			fd = open(path, ro ? O_RDONLY : O_RDWR);
-		}
-	}
-	
 	if (fd >= 0) {
 		if (size <= 0) {
 			struct stat st = { 0 };

--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -11,6 +11,8 @@
 
 #ifdef _WIN32
 #include "common_win32.h"
+#else
+#include <sys/wait.h>
 #endif
 
 #ifndef ZSIGN_VERSION
@@ -56,6 +58,64 @@ const struct option options[] = {
 	{"help", no_argument, NULL, 'h'},
 	{}
 };
+
+static bool InstallSignedIpa(const string& strOutputFile)
+{
+	if (strOutputFile.empty()) {
+		return false;
+	}
+
+#ifdef _WIN32
+	string strCommand = "ideviceinstaller install \"";
+	strCommand += strOutputFile;
+	strCommand += "\"";
+
+	STARTUPINFOA si;
+	PROCESS_INFORMATION pi;
+	memset(&si, 0, sizeof(si));
+	memset(&pi, 0, sizeof(pi));
+	si.cb = sizeof(si);
+
+	vector<char> arrCommand(strCommand.begin(), strCommand.end());
+	arrCommand.push_back('\0');
+	if (!CreateProcessA(NULL, arrCommand.data(), NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi)) {
+		ZLog::ErrorV(">>> Install failed to start ideviceinstaller! %s\n", strOutputFile.c_str());
+		return false;
+	}
+
+	WaitForSingleObject(pi.hProcess, INFINITE);
+	DWORD dwExitCode = 1;
+	GetExitCodeProcess(pi.hProcess, &dwExitCode);
+	CloseHandle(pi.hThread);
+	CloseHandle(pi.hProcess);
+	if (0 != dwExitCode) {
+		ZLog::ErrorV(">>> ideviceinstaller install failed! %s\n", strOutputFile.c_str());
+		return false;
+	}
+	return true;
+#else
+	pid_t pid = fork();
+	if (pid < 0) {
+		ZLog::ErrorV(">>> Install failed to fork ideviceinstaller! %s\n", strOutputFile.c_str());
+		return false;
+	}
+	if (0 == pid) {
+		execlp("ideviceinstaller", "ideviceinstaller", "install", strOutputFile.c_str(), (char*)NULL);
+		_exit(127);
+	}
+
+	int nStatus = 0;
+	if (waitpid(pid, &nStatus, 0) < 0) {
+		ZLog::ErrorV(">>> Install failed to wait ideviceinstaller! %s\n", strOutputFile.c_str());
+		return false;
+	}
+	if (!WIFEXITED(nStatus) || 0 != WEXITSTATUS(nStatus)) {
+		ZLog::ErrorV(">>> ideviceinstaller install failed! %s\n", strOutputFile.c_str());
+		return false;
+	}
+	return true;
+#endif
+}
 
 int usage()
 {
@@ -440,7 +500,7 @@ int main(int argc, char* argv[])
 
 	//install
 	if (bRet && bInstall) {
-		bRet = ZUtil::SystemExecV("ideviceinstaller install  \"%s\"", strOutputFile.c_str());
+		bRet = InstallSignedIpa(strOutputFile);
 	}
 
 	//clean


### PR DESCRIPTION
## Summary
- harden zip entry validation so Windows-style separators and drive-qualified paths cannot escape the extraction root
- stop relaxing file permissions in `ZFile::MapFile()` when an `open()` call fails
- replace the shell-based `ideviceinstaller` invocation with direct process execution to remove command injection risk from `-i`

## Verification
- rebuilt successfully with `make clean && make` in `build/macos`
- verified the install path no longer calls `SystemExecV("ideviceinstaller ...")`
- verified the POSIX `MapFile()` path no longer retries with `chmod(path, 0755)`
