### PR TITLE
fix: stage app into isolated Payload/ dir before archiving to IPA

### DIFF
--- a/src/zsign.cpp
+++ b/src/zsign.cpp
@@ -477,24 +477,42 @@ int main(int argc, char* argv[])
 
 	//archive
 	if (bRet && !strOutputFile.empty()) {
-		size_t pos = bundle.m_strAppFolder.rfind("Payload");
-		if (string::npos != pos && pos > 0) {
-			atimer.Reset();
-			ZLog::PrintV(">>> Archiving: \t%s ... \n", strOutputFile.c_str());
-			string strBaseFolder = bundle.m_strAppFolder.substr(0, pos - 1);
-			if (!Zip::Archive(strBaseFolder.c_str(), strOutputFile.c_str(), uZipLevel)) {
+		atimer.Reset();
+		ZLog::PrintV(">>> Archiving: \t%s ... \n", strOutputFile.c_str());
+
+		// Stage the signed app inside its own throwaway Payload/ folder (as a
+		// sibling of the app, so the move is a same-filesystem rename) instead
+		// of archiving from wherever the app happens to sit on disk. That
+		// guarantees the IPA only ever contains Payload/<app>, regardless of
+		// what other files/folders happen to live alongside the app.
+		string strAppFolder = bundle.m_strAppFolder;
+		size_t sepPos = strAppFolder.find_last_of("/\\");
+		string strParentFolder = (string::npos != sepPos) ? strAppFolder.substr(0, sepPos) : ".";
+		string strAppBaseName = ZUtil::GetBaseName(strAppFolder.c_str());
+
+		string strStageRoot = ZFile::GetRealPathV("%s/.zsign_stage_%llu", strParentFolder.c_str(), ZUtil::GetMicroSecond());
+		string strStagePayload = strStageRoot + "/Payload";
+		string strStageAppPath = strStagePayload + "/" + strAppBaseName;
+
+		ZFile::CreateFolder(strStagePayload.c_str());
+		if (0 != rename(strAppFolder.c_str(), strStageAppPath.c_str())) {
+			ZLog::ErrorV(">>> Failed to stage app folder for archiving! %s\n", strAppFolder.c_str());
+			ZFile::RemoveFolder(strStageRoot.c_str());
+			bRet = false;
+		} else {
+			bRet = Zip::Archive(strStageRoot.c_str(), strOutputFile.c_str(), uZipLevel);
+			rename(strStageAppPath.c_str(), strAppFolder.c_str()); // restore regardless of archive result
+			ZFile::RemoveFolder(strStageRoot.c_str());
+
+			if (!bRet) {
 				ZLog::Error(">>> Archive failed!\n");
-				bRet = false;
 			} else {
 				atimer.PrintResult(true, ">>> Archive OK! (%s)", ZFile::GetFileSizeString(strOutputFile.c_str()).c_str());
-				if (bRet && !strMetadataDir.empty()) {
+				if (!strMetadataDir.empty()) {
 					ZFile::CreateFolder(strMetadataDir.c_str());
 					GetMetadata(bundle.m_strAppFolder, strMetadataDir, strOutputFile);
 				}
 			}
-		} else {
-			ZLog::Error(">>> Can't find payload directory!\n");
-			bRet = false;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- The archive step derived the IPA's zip base folder by searching the signed app's absolute path for the literal string `Payload` and then zipping everything under its parent directory.
- When the app is signed in place (e.g. `zsign Payload/Runner.app` run directly from inside a real project directory, rather than from an extracted `.ipa`), that parent directory is the user's own project folder — so archiving swept in every unrelated sibling file/folder next to `Payload` (source, `node_modules`, build artifacts, etc.), producing a hugely bloated IPA.
- Fix: rename the signed app into a throwaway `Payload/` folder that is a sibling of the app on the same filesystem (cheap rename, not a copy), archive only that isolated folder, then move the app back to its original location. This guarantees the IPA always contains exactly `Payload/<app>`, independent of the app's path or what else lives alongside it on disk.

## Test plan
- [x] `make` build succeeds in `build/macos`
- [x] Isolated repro: created a mock `project/Payload/Runner.app` alongside a 50MB unrelated file and a `node_modules` folder, exercised the new staging/archive logic, confirmed the resulting IPA contains only `Payload/Runner.app/...` (a few hundred bytes) and the unrelated files are excluded
- [x] Confirmed the app folder is correctly restored to its original path afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)